### PR TITLE
Create a fake tag for testing archiving

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+      - name: Ensure tag
+        # Archving requires a tag, but we checkout only the last commit.
+        run: git describe --tags 2>/dev/null || git tag devel
       - name: Install requirements
         run: brew install meson diffoscope
       - name: Build


### PR DESCRIPTION
To create an archive we must have a tag, but we checkout only the last commit. Create a "devel" tag matching the fallback in meson.build.