### PR TITLE
Support on-disk unix socket

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-name: vfkit
+name: Integration
 
 on:
   pull_request:
@@ -12,9 +12,17 @@ on:
 
 jobs:
   example:
-    name: Example (vfkit)
+    name: Example
     # macos-15 (arm64) does not support nested virtualization yet.
     runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        driver: [vfkit, qemu]
+        connection: [fd, socket]
+        exclude:
+          - driver: qemu
+            connection: socket
     steps:
       - name: Host info
         run: |
@@ -22,8 +30,14 @@ jobs:
           sw_vers
           ifconfig
       - name: Install requirements
-        run: brew install meson qemu cdrtools coreutils
+        run: brew install meson qemu cdrtools coreutils tree
+      - name: Inspect qemu
+        # Looking up both prefixes to make it eaier to port to arm64 in the future.
+        run: |
+          tree -h /usr/local/share/qemu || true
+          tree -h /opt/homebrew/share/qemu || true
       - name: Install vfkit
+        if: matrix.driver == 'vfkit'
         run: |
           curl -LO https://github.com/crc-org/vfkit/releases/download/v0.6.0/vfkit
           sudo install vfkit /usr/local/bin/
@@ -53,15 +67,16 @@ jobs:
       - name: Start example VM
         run: |
           source .venv/bin/activate
-          ./example test -v &
+          ./example test --driver ${{ matrix.driver }} --connection ${{ matrix.connection }} -v &
           vm="$HOME/.vmnet-helper/vms/test"
           if ! timeout 5m bash -c "until test -f "$vm/ip-address"; do sleep 3; done"; then
               echo >&2 "Timeout waiting for $vm/ip-address"
               exit 1
           fi
-      - name: Logs
+      - name: Inspect example VM
         if: always()
         run: |
+          tree -h ~/.vmnet-helper
           head -n 500 ~/.vmnet-helper/vms/test/*.log /var/db/dhcpd_leases || true
       - name: Prepare example VM
         run: |

--- a/example
+++ b/example
@@ -318,7 +318,7 @@ def start_vm(args, mac_address, fd=None, socket=None):
     with open(vm_path(args.vm_name, f"{args.driver}.log"), "w") as log:
         pass_fds = [fd] if fd is not None else []
         vm = subprocess.Popen(cmd, stderr=log, pass_fds=pass_fds)
-    lookup_ip_address(args, serial)
+    wait_for_ip_address(vm, args, serial)
     return vm
 
 
@@ -391,18 +391,20 @@ def qemu_command(args, mac_address, image, disk, cidata, serial, fd=None, socket
     ]
 
 
-def lookup_ip_address(args, serial, timeout=300):
+def wait_for_ip_address(vm, args, serial, timeout=300):
     """
     Lookup the vm ip address in the serial log and write to
     vm_home/ip-address.
     """
     prefix = f"{args.vm_name} address: "
     for line in tail(serial, timeout):
+        check_vm(vm)
         if line.startswith(prefix):
             ip_address = line[len(prefix) :]
             print(f"Virtual machine IP address: {ip_address}")
             write_ip_address(args.vm_name, ip_address)
             return
+    check_vm(vm)
     print("Timeout looking up ip address")
 
 
@@ -443,6 +445,11 @@ def stream(file, timeout):
                 if not data:
                     break
                 yield data
+
+
+def check_vm(vm):
+    if vm.poll() is not None:
+        raise RuntimeError(f"Virtual machine terminated (exitcode {vm.poll()})")
 
 
 def write_ip_address(vm_name, ip_address):

--- a/example
+++ b/example
@@ -83,6 +83,12 @@ def main():
         help="Number of vpus (1)",
     )
     p.add_argument(
+        "--memory",
+        type=int,
+        default=1024,
+        help="Memory size in MiB (1024)",
+    )
+    p.add_argument(
         "--bridged", metavar="INTERFACE", help="Create bridged network using interface"
     )
     p.add_argument(
@@ -326,7 +332,7 @@ def vfkit_command(args, mac_address, image, disk, cidata, serial, fd=None, socke
     efi_store = vm_path(args.vm_name, "efi-variable-store")
     cmd = [
         "vfkit",
-        "--memory=2048",
+        f"--memory={args.memory}",
         f"--cpus={args.cpus}",
         f"--bootloader=efi,variable-store={efi_store},create",
         f"--device=usb-mass-storage,path={cidata},readonly",
@@ -375,7 +381,7 @@ def qemu_command(args, mac_address, image, disk, cidata, serial, fd=None, socket
         "-name",
         args.vm_name,
         "-m",
-        "2048",
+        f"{args.memory}",
         "-cpu",
         "host",
         "-machine",

--- a/example
+++ b/example
@@ -56,8 +56,8 @@ RECV_BUFSIZE = 2 * 1024 * 1024
 # address.
 # TODO: find a way to detect this programmatically instead of hard coding.
 SERIAL_CONSOLE = {
-    "vfkit": "/dev/hvc0",
-    "qemu": "/dev/ttyAMA0",
+    "vfkit": {"arm64": "hvc0", "x86_64": "hvc0"},
+    "qemu": {"arm64": "ttyAMA0", "x86_64": "ttyS0"},
 }
 
 
@@ -343,6 +343,18 @@ def vfkit_command(args, mac_address, image, disk, cidata, serial, fd=None, socke
     return cmd
 
 
+QEMU_CONFIG = {
+    "arm64": {
+        "arch": "aarch64",
+        "machine": "virt",
+    },
+    "x86_64": {
+        "arch": "x86_64",
+        "machine": "q35",
+    },
+}
+
+
 def qemu_command(args, mac_address, image, disk, cidata, serial, fd=None, socket=None):
     if fd is not None:
         netdev = f"dgram,id=net1,local.type=fd,local.str={fd}"
@@ -356,9 +368,10 @@ def qemu_command(args, mac_address, image, disk, cidata, serial, fd=None, socket
         raise ValueError("socket connection not supported for qemu driver")
     else:
         raise ValueError("fd or socket required")
-
+    qemu = QEMU_CONFIG[platform.machine()]
+    firmware = qemu_firmware(qemu["arch"])
     return [
-        "qemu-system-aarch64",
+        f"qemu-system-{qemu['arch']}",
         "-name",
         args.vm_name,
         "-m",
@@ -366,11 +379,11 @@ def qemu_command(args, mac_address, image, disk, cidata, serial, fd=None, socket
         "-cpu",
         "host",
         "-machine",
-        "virt,accel=hvf",
+        f"{qemu['machine']},accel=hvf",
         "-smp",
         f"{args.cpus},sockets=1,cores={args.cpus},threads=1",
         "-drive",
-        "if=pflash,format=raw,readonly=on,file=/opt/homebrew/share/qemu/edk2-aarch64-code.fd",
+        f"if=pflash,format=raw,readonly=on,file={firmware}",
         "-drive",
         f"file={disk},if=virtio,format=raw,discard=on",
         "-drive",
@@ -389,6 +402,21 @@ def qemu_command(args, mac_address, image, disk, cidata, serial, fd=None, socket
         f"file:{serial}",
         "-nographic",
     ]
+
+
+def qemu_firmware(arch):
+    """
+    Based on https://github.com/lima-vm/lima/blob/master/pkg/qemu/qemu.go.
+    """
+    filename = f"edk2-{arch}-code.fd"
+    candidates = [
+        f"/opt/homebrew/share/qemu/{filename}",  # Apple silicon
+        f"/usr/local/share/qemu/{filename}",  # macos-13 github runner
+    ]
+    for path in candidates:
+        if os.path.exists(path):
+            return path
+    raise RuntimeError(f"Unable to find firmware: {candidates}")
 
 
 def wait_for_ip_address(vm, args, serial, timeout=300):
@@ -513,7 +541,7 @@ def create_user_data(args):
     """
     Create cloud-init user-data file.
     """
-    serial_console = SERIAL_CONSOLE[args.driver]
+    serial_console = f"/dev/{SERIAL_CONSOLE[args.driver][platform.machine()]}"
     path = vm_path(args.vm_name, "user-data")
     data = {
         "password": "password",

--- a/example
+++ b/example
@@ -66,7 +66,7 @@ def main():
     p.add_argument("vm_name", help="VM name")
     p.add_argument(
         "--connection",
-        choices=["fd"],
+        choices=["fd", "socket"],
         default="fd",
         help="How to connect the helper and vm (fd)",
     )
@@ -96,6 +96,8 @@ def main():
 
     if args.connection == "fd":
         run_with_fd(args)
+    elif args.connection == "socket":
+        run_with_socket(args)
 
 
 def run_with_fd(args):
@@ -109,10 +111,31 @@ def run_with_fd(args):
     vm_sock, helper_sock = create_socketpair()
 
     # Start vmnet-helper first, since we need the MAC address for starting the VM.
-    helper, mac_address = start_helper(args, helper_sock.fileno())
+    helper, mac_address = start_helper(args, fd=helper_sock.fileno())
     try:
         # Start the VM with the second socket and the MAC address.
-        vm = start_vm(args, vm_sock.fileno(), mac_address)
+        vm = start_vm(args, mac_address, fd=vm_sock.fileno())
+        vm.wait()
+    except KeyboardInterrupt:
+        print("Terminating")
+    finally:
+        cleanup(args, vm, helper)
+
+
+def run_with_socket(args):
+    """
+    Use unix socket to connect the vm and the helper.
+    """
+    vm = None
+
+    # The helper will create a unix datagram socket at this path and wait for client connection.
+    socket = vm_path(args.vm_name, "vmnet.sock")
+
+    # Start vmnet-helper first, since we need the MAC address for starting the VM.
+    helper, mac_address = start_helper(args, socket=socket)
+    try:
+        # Start the VM with the MAC address and socket.
+        vm = start_vm(args, mac_address, socket=socket)
         vm.wait()
     except KeyboardInterrupt:
         print("Terminating")
@@ -201,25 +224,40 @@ def create_socketpair():
     return pair
 
 
-def start_helper(args, helper_fd):
+def start_helper(args, fd=None, socket=None):
     """
-    Starts vmnet-helper with helper_fd.
+    Starts vmnet-helper with fd or socket.
     """
     interface_id = interface_id_from(args.vm_name)
     print(
         f"Starting vmnet-helper for '{args.vm_name}' with interface id '{interface_id}'"
     )
-    cmd = [
-        "sudo",
-        "--non-interactive",
-        f"--close-from={helper_fd+1}",
-        "/opt/vmnet-helper/bin/vmnet-helper",
-        f"--fd={helper_fd}",
-        f"--interface-id={interface_id}",
-    ]
+    if fd is not None:
+        cmd = [
+            "sudo",
+            "--non-interactive",
+            f"--close-from={fd+1}",
+            "/opt/vmnet-helper/bin/vmnet-helper",
+            f"--fd={fd}",
+        ]
+        pass_fds = [fd]
+    elif socket is not None:
+        cmd = [
+            "sudo",
+            "--non-interactive",
+            "/opt/vmnet-helper/bin/vmnet-helper",
+            f"--socket={socket}",
+        ]
+        pass_fds = []
+    else:
+        raise ValueError("fd or socket required")
+
+    cmd.append(f"--interface-id={interface_id}")
+
     if args.bridged:
         cmd.append("--operation-mode=bridged")
         cmd.append(f"--shared-interface={args.bridged}")
+
     if args.verbose:
         cmd.append("--verbose")
 
@@ -229,7 +267,7 @@ def start_helper(args, helper_fd):
             cmd,
             stdout=subprocess.PIPE,
             stderr=log,
-            pass_fds=[helper_fd],
+            pass_fds=pass_fds,
         )
     try:
         reply = helper.stdout.readline()  # type: ignore[attr-defined]
@@ -255,18 +293,22 @@ def interface_id_from(name):
     return str(uuid.UUID(bytes=md[:16], version=4))
 
 
-def start_vm(args, vm_fd, mac_address):
+def start_vm(args, mac_address, fd=None, socket=None):
     """
-    Starts a vfkit VM using the vm_fd and mac_address.
+    Starts a VM driver with fd or socket.
     """
     image = create_image(args)
     disk = create_disk(args, image)
     cidata = create_cidata(args, mac_address)
     serial = vm_path(args.vm_name, "serial.log")
     if args.driver == "vfkit":
-        cmd = vfkit_command(args, vm_fd, mac_address, image, disk, cidata, serial)
+        cmd = vfkit_command(
+            args, mac_address, image, disk, cidata, serial, fd=fd, socket=socket
+        )
     elif args.driver == "qemu":
-        cmd = qemu_command(args, vm_fd, mac_address, image, disk, cidata, serial)
+        cmd = qemu_command(
+            args, mac_address, image, disk, cidata, serial, fd=fd, socket=socket
+        )
     else:
         raise ValueError(f"Invalid driver '{args.driver}'")
     print(
@@ -274,27 +316,47 @@ def start_vm(args, vm_fd, mac_address):
     )
     silent_remove(serial)
     with open(vm_path(args.vm_name, f"{args.driver}.log"), "w") as log:
-        vm = subprocess.Popen(cmd, stderr=log, pass_fds=[vm_fd])
+        pass_fds = [fd] if fd is not None else []
+        vm = subprocess.Popen(cmd, stderr=log, pass_fds=pass_fds)
     lookup_ip_address(args, serial)
     return vm
 
 
-def vfkit_command(args, vm_fd, mac_address, image, disk, cidata, serial):
+def vfkit_command(args, mac_address, image, disk, cidata, serial, fd=None, socket=None):
     efi_store = vm_path(args.vm_name, "efi-variable-store")
-    return [
+    cmd = [
         "vfkit",
         "--memory=2048",
         f"--cpus={args.cpus}",
         f"--bootloader=efi,variable-store={efi_store},create",
         f"--device=usb-mass-storage,path={cidata},readonly",
         f"--device=virtio-blk,path={disk}",
-        f"--device=virtio-net,fd={vm_fd},mac={mac_address}",
         f"--device=virtio-serial,logFilePath={serial}",
         "--log-level=debug",
     ]
+    if fd is not None:
+        cmd.append(f"--device=virtio-net,fd={fd},mac={mac_address}")
+    elif socket is not None:
+        cmd.append(f"--device=virtio-net,unixSocketPath={socket},mac={mac_address}")
+    else:
+        raise ValueError("fd or socket required")
+    return cmd
 
 
-def qemu_command(args, vm_fd, mac_address, image, disk, cidata, serial):
+def qemu_command(args, mac_address, image, disk, cidata, serial, fd=None, socket=None):
+    if fd is not None:
+        netdev = f"dgram,id=net1,local.type=fd,local.str={fd}"
+    elif socket is not None:
+        # qemu support unix datagram socket, but it rquires local and remote sockets:
+        #   -netdev dgram,id=str,local.type=unix,local.path=path[,remote.type=unix,remote.path=path]
+        # The remote parameters look optional but they are required.  Trying to
+        # use the helper socket with local.path and remote.path does not work.
+        # Maybe it tries to connect to the helper socket twice, and the helper
+        # ignores the second client.
+        raise ValueError("socket connection not supported for qemu driver")
+    else:
+        raise ValueError("fd or socket required")
+
     return [
         "qemu-system-aarch64",
         "-name",
@@ -318,7 +380,7 @@ def qemu_command(args, vm_fd, mac_address, image, disk, cidata, serial):
         "-device",
         "scsi-cd,bus=scsi0.0,drive=cdrom0",
         "-netdev",
-        f"dgram,id=net1,local.type=fd,local.str={vm_fd}",
+        netdev,
         "-device",
         f"virtio-net-pci,netdev=net1,mac={mac_address}",
         "-monitor",

--- a/example
+++ b/example
@@ -65,6 +65,12 @@ def main():
     p = argparse.ArgumentParser(description="Run virtual machine using vmnet-helper")
     p.add_argument("vm_name", help="VM name")
     p.add_argument(
+        "--connection",
+        choices=["fd"],
+        default="fd",
+        help="How to connect the helper and vm (fd)",
+    )
+    p.add_argument(
         "--driver",
         choices=["vfkit", "qemu"],
         default="vfkit",
@@ -88,6 +94,16 @@ def main():
     p.add_argument("-v", "--verbose", action="store_true", help="Be more verbose")
     args = p.parse_args()
 
+    if args.connection == "fd":
+        run_with_fd(args)
+
+
+def run_with_fd(args):
+    """
+    Use file descriptor passing to connect the vm and the helper.
+    """
+    vm = None
+
     # Create a socketpair for the child processes. The vm_sock will be used by
     # the vm, and the host_sock will be used by the helper.
     vm_sock, helper_sock = create_socketpair()
@@ -101,11 +117,19 @@ def main():
     except KeyboardInterrupt:
         print("Terminating")
     finally:
+        cleanup(args, vm, helper)
+
+
+def cleanup(args, vm, helper):
+    """
+    Stop child processes and clean up vm directory.
+    """
+    if vm:
         delete_ip_address(args.vm_name)
         vm.terminate()
-        helper.terminate()
         vm.wait()
-        helper.wait()
+    helper.terminate()
+    helper.wait()
 
 
 def cpus(s):

--- a/options.h
+++ b/options.h
@@ -9,6 +9,7 @@
 
 struct options {
     int fd;
+    const char *socket;
     uint32_t operation_mode;
     uuid_t interface_id;
     const char *start_address;


### PR DESCRIPTION
This change add a --socket option, allowing simpler (but less secure) usage from a shell script, and integration with krunkit that does not support passing file descriptor.

When using a socket instead of passing a file descriptor, the helper creates a unix datagram socket and wait for the client. When a client send the first packet, the helper connects to the client socket, and continue with the normal flow.

Tested with vfkit, performance is identical to --fd option.

Fixes #17 