### PR TITLE
Integration with krunkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,35 +195,47 @@ vmnet-helper is up to *10.4 times faster* compared to
 Virtualization framework, and up to *3.0 times faster* compared to
 [softnet](https://github.com/cirruslabs/softnet).
 
+With [krunkit](https://github.com/containers/krunkit) vm to vm
+performance is similar to [tart](https://tart.run/), using native
+bridged network.
+
 ### iMac M3
 
 Results from iMac M3 running macOS 15.2, testing only shared mode
 (192.168.105/24).
 
-| network      | mode   | vm     | host to vm     | cpu  | vm to vm      | cpu  |
-|--------------|--------|--------|----------------|------|---------------|------|
-| vmnet-helper | shared | vfkit  |   13.0 Gbits/s |  61% |  17.2 Gbits/s |  69% |
-| vmnet-helper | shared | qemu   |    3.0 Gbits/s |  23% |   2.9 Gbits/s |  31% |
-| softnet      | shared | tart   |    9.5 Gbits/s |  97% |   5.7 Gbits/s |  90% |
-| socket_vmnet | shared | vz     |    3.9 Gbits/s |  81% |   1.9 Gbits/s |  91% |
-| socket_vmnet | shared | qemu   |    3.8 Gbits/s |  41% |   2.5 Gbits/s |  78% |
+| network      | mode   | vm          | host to vm     | cpu  | vm to vm      | cpu  |
+|--------------|--------|-------------|----------------|------|---------------|------|
+| vmnet-helper | shared | vfkit       |   13.0 Gbits/s |  61% |  17.2 Gbits/s |  69% |
+| vmnet-helper | shared | qemu        |    3.0 Gbits/s |  23% |   2.9 Gbits/s |  31% |
+| softnet      | shared | tart        |    9.5 Gbits/s |  97% |   5.7 Gbits/s |  90% |
+| socket_vmnet | shared | vz          |    3.9 Gbits/s |  81% |   1.9 Gbits/s |  91% |
+| socket_vmnet | shared | qemu        |    3.8 Gbits/s |  41% |   2.5 Gbits/s |  78% |
 
 ### MacBook Pro M2 Max
 
 Results from MacBook Pro M2 Max running macOS 15.2, testing both shared
 and bridged modes.
 
-| network      | mode    | vm     | host to vm     | cpu  | vm to vm      | cpu  |
-|--------------|---------|--------|----------------|------|---------------|------|
-| vmnet-helper | shared  | vfkit  |   10.5 Gbits/s |  71% |  13.5 Gbits/s |  88% |
-| vmnet-helper | bridged | vfkit  |   13.0 Gbits/s |  88% |  12.9 Gbits/s |  86% |
-| vmnet-helper | shared  | qemu   |    2.7 Gbits/s |  20% |   2.4 Gbits/s |  35% |
-| softnet      | shared  | tart   |    5.5 Gbits/s |  98% |   5.4 Gbits/s | 100% |
-| vz           | bridged | tart   |    5.3 Gbits/s |    - |  35.9 Gbits/s |    - |
-| socket_vmnet | shared  | vz     |    2.5 Gbits/s |  95% |   1.3 Gbits/s | 130% |
-| socket_vmnet | shared  | qemu   |    2.8 Gbits/s |  41% |   1.4 Gbits/s | 104% |
+Using iperf3 `--length 1m` option.
 
-Note: using iperf3 `--length 1m` option
+| network      | mode    | vm         | host to vm     | cpu  | vm to vm      | cpu  |
+|--------------|---------|------------|----------------|------|---------------|------|
+| vmnet-helper | shared  | vfkit      |   10.5 Gbits/s |  71% |  13.5 Gbits/s |  88% |
+| vmnet-helper | bridged | vfkit      |   13.0 Gbits/s |  88% |  12.9 Gbits/s |  86% |
+| vmnet-helper | shared  | krunkit[1] |    1.4 Gbits/s |  33% |  29.9 Gbits/s |  63% |
+| vmnet-helper | bridged | krunkit[1] |    1.4 Gbits/s |  34% |  31.0 Gbits/s |  63% |
+| vmnet-helper | shared  | krunkit[2] |    9.8 Gbits/s |  70% |   9.4 Gbits/s |  84% |
+| vmnet-helper | bridged | krunkit[2] |    9.9 Gbits/s |  94% |   8.9 Gbits/s |  88% |
+| vmnet-helper | shared  | qemu       |    2.7 Gbits/s |  20% |   2.4 Gbits/s |  35% |
+| softnet      | shared  | tart       |    5.5 Gbits/s |  98% |   5.4 Gbits/s | 100% |
+| vz           | bridged | tart       |    5.3 Gbits/s |    - |  35.9 Gbits/s |    - |
+| socket_vmnet | shared  | vz         |    2.5 Gbits/s |  95% |   1.3 Gbits/s | 130% |
+| socket_vmnet | shared  | qemu       |    2.8 Gbits/s |  41% |   1.4 Gbits/s | 104% |
+
+Notes:
+- [1] krunkit built with libkrun upstream
+- [2] krunkit built with libkrun patched to disable offloading
 
 ## Performance testing
 

--- a/example
+++ b/example
@@ -44,13 +44,16 @@ IMAGES = {
     },
 }
 
-# Apple recommends that the receive buffer is 4 times bigger than the send
-# buffer, but the send buffer is not used for buffering in datagram sockets, it
-# only limits the maximum datagram size. Based on Apple docs the vmnet maximum
-# packet size is 64k. Bigger receive buffer reduces ENOBUFS errors and increase
-# throughput. Testing shows that more than 2 MiB is not needed.
-SEND_BUFSIZE = 64 * 1024
-RECV_BUFSIZE = 2 * 1024 * 1024
+# Apple recommend receive buffer size to be 4 times the size of the send
+# buffer size, but send buffer size is not used to allocate a buffer in
+# datagram sockets, it only limits the maximum packet size.
+# Must be larger than TSO packets size (65550 bytes).
+SEND_BUFSIZE = 65 * 1024
+
+# The receive buffer size determine how many packets can be queued by the
+# peer. Using bigger receive buffer size make ENOBUFS error less likey for the
+# peer and improves throughput.
+RECV_BUFSIZE = 4 * 1024 * 1024
 
 # The serial console device in the guest, used to communicate the guest ip
 # address.

--- a/example
+++ b/example
@@ -60,7 +60,22 @@ RECV_BUFSIZE = 4 * 1024 * 1024
 # TODO: find a way to detect this programmatically instead of hard coding.
 SERIAL_CONSOLE = {
     "vfkit": {"arm64": "hvc0", "x86_64": "hvc0"},
+    "krunkit": {"arm64": "hvc0", "x86_64": "hvc0"},
     "qemu": {"arm64": "ttyAMA0", "x86_64": "ttyS0"},
+}
+
+CONNECTION_AUTO = {
+    "vfkit": "fd",
+    "krunkit": "socket",
+    "qemu": "fd",
+}
+
+VMNET_OFFLOAD_AUTO = {
+    "vfkit": "off",
+    # libkrun enables offloading feautres by default, so we must enable vmnet
+    # offloading.  See https://github.com/containers/libkrun/issues/264
+    "krunkit": "on",
+    "qemu": "off",
 }
 
 
@@ -69,15 +84,21 @@ def main():
     p.add_argument("vm_name", help="VM name")
     p.add_argument(
         "--connection",
-        choices=["fd", "socket"],
-        default="fd",
-        help="How to connect the helper and vm (fd)",
+        choices=["auto", "fd", "socket"],
+        default="auto",
+        help="How to connect the helper and vm (auto)",
     )
     p.add_argument(
         "--driver",
-        choices=["vfkit", "qemu"],
+        choices=["vfkit", "krunkit", "qemu"],
         default="vfkit",
         help="VM driver (vfkit)",
+    )
+    p.add_argument(
+        "--krunkit-port",
+        type=int,
+        default=8081,
+        help="krunkit restful-uri port (8081)",
     )
     p.add_argument(
         "--cpus",
@@ -95,6 +116,12 @@ def main():
         "--bridged", metavar="INTERFACE", help="Create bridged network using interface"
     )
     p.add_argument(
+        "--vmnet-offload",
+        choices=["auto", "on", "off"],
+        default="auto",
+        help="Enable vment tso and checksum-offload options (auto)",
+    )
+    p.add_argument(
         "--distro",
         choices=list(IMAGES.keys()),
         default="ubuntu",
@@ -102,6 +129,12 @@ def main():
     )
     p.add_argument("-v", "--verbose", action="store_true", help="Be more verbose")
     args = p.parse_args()
+
+    if args.connection == "auto":
+        args.connection = CONNECTION_AUTO[args.driver]
+
+    if args.vmnet_offload == "auto":
+        args.vmnet_offload = VMNET_OFFLOAD_AUTO[args.driver]
 
     if args.connection == "fd":
         run_with_fd(args)
@@ -270,6 +303,9 @@ def start_helper(args, fd=None, socket=None):
     if args.verbose:
         cmd.append("--verbose")
 
+    if args.vmnet_offload == "on":
+        cmd.extend(["--enable-tso", "--enable-checksum-offload"])
+
     os.makedirs(vm_path(args.vm_name), exist_ok=True)
     with open(vm_path(args.vm_name, "vmnet-helper.log"), "w") as log:
         helper = subprocess.Popen(
@@ -314,6 +350,10 @@ def start_vm(args, mac_address, fd=None, socket=None):
         cmd = vfkit_command(
             args, mac_address, image, disk, cidata, serial, fd=fd, socket=socket
         )
+    elif args.driver == "krunkit":
+        cmd = krunkit_command(
+            args, mac_address, image, disk, cidata, serial, fd=fd, socket=socket
+        )
     elif args.driver == "qemu":
         cmd = qemu_command(
             args, mac_address, image, disk, cidata, serial, fd=fd, socket=socket
@@ -350,6 +390,28 @@ def vfkit_command(args, mac_address, image, disk, cidata, serial, fd=None, socke
     else:
         raise ValueError("fd or socket required")
     return cmd
+
+
+def krunkit_command(
+    args, mac_address, image, disk, cidata, serial, fd=None, socket=None
+):
+    if fd is not None:
+        raise ValueError("fd connection not supported for krunkit driver")
+    if socket is None:
+        raise ValueError("socket connection required")
+    return [
+        # krunkit from brew is not compatible with libkrun from brew. Using
+        # local build with latest libkrun.
+        "krunkit.local",
+        f"--memory={args.memory}",
+        f"--cpus={args.cpus}",
+        f"--restful-uri=tcp://localhost:{args.krunkit_port}",
+        f"--device=virtio-blk,path={disk},format=raw",
+        f"--device=virtio-blk,path={cidata},format=raw",
+        f"--device=virtio-net,unixSocketPath={socket},mac={mac_address}",
+        f"--device=virtio-serial,logFilePath={serial}",
+        f"--krun-log-level=3",
+    ]
 
 
 QEMU_CONFIG = {

--- a/example
+++ b/example
@@ -407,6 +407,7 @@ def qemu_command(args, mac_address, image, disk, cidata, serial, fd=None, socket
         "-serial",
         f"file:{serial}",
         "-nographic",
+        "-nodefaults",
     ]
 
 

--- a/helper.c
+++ b/helper.c
@@ -54,11 +54,14 @@
 
 // Apple recommend receive buffer size to be 4 times the size of the send
 // buffer size, but send buffer size is not used to allocate a buffer in
-// datagram sockets, it only limits the maximum packet size. The receive buffer
-// size determine how many packets can be queued. Using bigger receive buffer
-// size reduces number of retries and improves throughput.
-static const int SNDBUF_SIZE = 64 * 1024;
-static const int RCVBUF_SIZE = 2 * 1024 * 1024;
+// datagram sockets, it only limits the maximum packet size.
+// Must be larger than TSO packets size (65550 bytes).
+static const int SNDBUF_SIZE = 65 * 1024;
+
+// The receive buffer size determine how many packets can be queued by the
+// peer. Using bigger receive buffer size make ENOBUFS error less likey for the
+// peer and improves throughput.
+static const int RCVBUF_SIZE = 4 * 1024 * 1024;
 
 static const uintptr_t SHUTDOWN_EVENT = 1;
 

--- a/helper.c
+++ b/helper.c
@@ -251,6 +251,9 @@ static void start_host_interface(void)
         xpc_dictionary_set_string(desc, vmnet_subnet_mask_key, options.subnet_mask);
     }
 
+    xpc_dictionary_set_bool(desc, vmnet_enable_tso_key, options.enable_tso);
+    xpc_dictionary_set_bool(desc, vmnet_enable_checksum_offload_key, options.enable_checksum_offload);
+
     dispatch_semaphore_t completed = dispatch_semaphore_create(0);
 
     interface = vmnet_start_interface(

--- a/options.c
+++ b/options.c
@@ -29,6 +29,7 @@ static void usage(int code)
 "    vmnet-helper (--fd FD|--socket SOCKET) [--interface-id UUID]\n"
 "                 [--operation-mode shared|bridged|host] [--shared-interface NAME]\n"
 "                 [--start-address ADDR] [--end-address ADDR] [--subnet-mask MASK]\n"
+"                 [--enable-tso] [--enable-checksum-offload]\n"
 "                 [-v|--verbose] [--version] [-h|--help]\n"
 "\n";
     fputs(msg, stderr);
@@ -41,24 +42,28 @@ enum {
     OPT_START_ADDRESS,
     OPT_END_ADDRESS,
     OPT_SUBNET_MASK,
+    OPT_ENABLE_TSO,
+    OPT_ENABLE_CHECKSUM_OFFLOAD,
     OPT_VERSION,
 };
 
 static const char *short_options = ":f:s:i:vh";
 
 static struct option long_options[] = {
-    {"fd",                  required_argument,  0,  'f'},
-    {"socket",              required_argument,  0,  's'},
-    {"interface-id",        required_argument,  0,  'i'},
-    {"operation-mode",      required_argument,  0,  OPT_OPERATION_MODE},
-    {"shared-interface",    required_argument,  0,  OPT_SHARED_INTERFACE},
-    {"start-address",       required_argument,  0,  OPT_START_ADDRESS},
-    {"end-address",         required_argument,  0,  OPT_END_ADDRESS},
-    {"subnet-mask",         required_argument,  0,  OPT_SUBNET_MASK},
-    {"verbose",             no_argument,        0,  'v'},
-    {"version",             no_argument,        0,  OPT_VERSION},
-    {"help",                no_argument,        0,  'h'},
-    {0,                     0,                  0,  0},
+    {"fd",                      required_argument,  0,  'f'},
+    {"socket",                  required_argument,  0,  's'},
+    {"interface-id",            required_argument,  0,  'i'},
+    {"operation-mode",          required_argument,  0,  OPT_OPERATION_MODE},
+    {"shared-interface",        required_argument,  0,  OPT_SHARED_INTERFACE},
+    {"start-address",           required_argument,  0,  OPT_START_ADDRESS},
+    {"end-address",             required_argument,  0,  OPT_END_ADDRESS},
+    {"subnet-mask",             required_argument,  0,  OPT_SUBNET_MASK},
+    {"enable-tso",              no_argument,        0,  OPT_ENABLE_TSO},
+    {"enable-checksum-offload", no_argument,        0,  OPT_ENABLE_CHECKSUM_OFFLOAD},
+    {"verbose",                 no_argument,        0,  'v'},
+    {"version",                 no_argument,        0,  OPT_VERSION},
+    {"help",                    no_argument,        0,  'h'},
+    {0,                         0,                  0,  0},
 };
 
 static void parse_fd(const char *arg, int *fd)
@@ -183,6 +188,12 @@ void parse_options(struct options *opts, int argc, char **argv)
             break;
         case OPT_SUBNET_MASK:
             parse_address(optarg, optname, &opts->subnet_mask);
+            break;
+        case OPT_ENABLE_TSO:
+            opts->enable_tso = true;
+            break;
+        case OPT_ENABLE_CHECKSUM_OFFLOAD:
+            opts->enable_checksum_offload = true;
             break;
         case 'v':
             verbose = true;

--- a/options.h
+++ b/options.h
@@ -16,6 +16,8 @@ struct options {
     const char *end_address;
     const char *subnet_mask;
     const char *shared_interface;
+    bool enable_tso;
+    bool enable_checksum_offload;
     uid_t uid;
     gid_t gid;
 };


### PR DESCRIPTION
Add krunkit example tested with upstream krunkit.

- Add --driver krunkit
- Add --krunkit-port, required for running multiple krunkit vms.
- Add --vmnet-offload {auto,on,off}, required for testing krunkit upstream.

Example run:

```console
% ./example server --driver krunkit
Starting vmnet-helper for 'server' with interface id 'bdc7b3e0-8594-4814-aa25-05187ad2a36e'
Creating cloud-init iso '/Users/nir/.vmnet-helper/vms/server/cidata.iso'
Starting 'krunkit' virtual machine 'server' with mac address '92:c9:52:b7:6c:08'
Virtual machine IP address: 192.168.105.2
```

Upstream libkrun enables offloading features, showing very inconsistent performance. When disabling offloading, it shows similar performance as vfkit.

| network      | mode    | vm         | host to vm     | cpu  | vm to vm      | cpu  |
|--------------|---------|------------|----------------|------|---------------|------|
| vmnet-helper | shared  | vfkit      |   10.5 Gbits/s |  71% |  13.5 Gbits/s |  88% |
| vmnet-helper | bridged | vfkit      |   13.0 Gbits/s |  88% |  12.9 Gbits/s |  86% |
| vmnet-helper | shared  | krunkit[1] |    1.4 Gbits/s |  33% |  29.9 Gbits/s |  63% |
| vmnet-helper | bridged | krunkit[1] |    1.4 Gbits/s |  34% |  31.0 Gbits/s |  63% |
| vmnet-helper | shared  | krunkit[2] |    9.8 Gbits/s |  70% |   9.4 Gbits/s |  84% |
| vmnet-helper | bridged | krunkit[2] |    9.9 Gbits/s |  94% |   8.9 Gbits/s |  88% |

[1] krunkit built with libkrun upstream
[2] krunkit built with libkrun patched to disable offloading

Based on #22 
Fixes #18 