### PR TITLE
Add --enable-isolation option

### DIFF
--- a/example
+++ b/example
@@ -123,6 +123,11 @@ def main():
         help="vmnet shared interface, required for --operation-mode=bridged",
     )
     p.add_argument(
+        "--enable-isolation",
+        action="store_true",
+        help="Isolate the guest from other guests on the vmnet interface, requires --operation-mode=host",
+    )
+    p.add_argument(
         "--vmnet-offload",
         choices=["auto", "on", "off"],
         default="auto",
@@ -142,6 +147,9 @@ def main():
 
     if args.operation_mode == "bridged" and not args.shared_interface:
         p.error("--shared-interface required for --operation-mode=bridged")
+
+    if args.enable_isolation and args.operation_mode != "host":
+        p.error("--enable-isolation requires --operation-mode=host")
 
     if args.vmnet_offload == "auto":
         args.vmnet_offload = VMNET_OFFLOAD_AUTO[args.driver]
@@ -309,6 +317,9 @@ def start_helper(args, fd=None, socket=None):
 
     if args.shared_interface:
         cmd.append(f"--shared-interface={args.shared_interface}")
+
+    if args.enable_isolation:
+        cmd.append("--enable-isolation")
 
     if args.verbose:
         cmd.append("--verbose")

--- a/helper.c
+++ b/helper.c
@@ -246,13 +246,21 @@ static void start_host_interface(void)
     xpc_dictionary_set_uuid(desc, vmnet_interface_id_key, options.interface_id);
     xpc_dictionary_set_uint64(desc, vmnet_operation_mode_key, options.operation_mode);
 
-    if (options.operation_mode == VMNET_BRIDGED_MODE) {
+    switch (options.operation_mode) {
+    case VMNET_BRIDGED_MODE:
         xpc_dictionary_set_string(desc, vmnet_shared_interface_name_key, options.shared_interface);
-    } else if (options.operation_mode == VMNET_SHARED_MODE) {
+        break;
+    case VMNET_SHARED_MODE:
         xpc_dictionary_set_string(desc, vmnet_start_address_key, options.start_address);
         xpc_dictionary_set_string(desc, vmnet_end_address_key, options.end_address);
         xpc_dictionary_set_string(desc, vmnet_subnet_mask_key, options.subnet_mask);
-    }
+        break;
+    case VMNET_HOST_MODE:
+        xpc_dictionary_set_bool(desc, vmnet_enable_isolation_key, options.enable_isolation);
+        break;
+    default:
+        assert(0);
+    };
 
     xpc_dictionary_set_bool(desc, vmnet_enable_tso_key, options.enable_tso);
     xpc_dictionary_set_bool(desc, vmnet_enable_checksum_offload_key, options.enable_checksum_offload);

--- a/options.c
+++ b/options.c
@@ -29,7 +29,7 @@ static void usage(int code)
 "    vmnet-helper (--fd FD|--socket SOCKET) [--interface-id UUID]\n"
 "                 [--operation-mode shared|bridged|host] [--shared-interface NAME]\n"
 "                 [--start-address ADDR] [--end-address ADDR] [--subnet-mask MASK]\n"
-"                 [--enable-tso] [--enable-checksum-offload]\n"
+"                 [--enable-tso] [--enable-checksum-offload] [--enable-isolation]\n"
 "                 [-v|--verbose] [--version] [-h|--help]\n"
 "\n";
     fputs(msg, stderr);
@@ -44,6 +44,7 @@ enum {
     OPT_SUBNET_MASK,
     OPT_ENABLE_TSO,
     OPT_ENABLE_CHECKSUM_OFFLOAD,
+    OPT_ENABLE_ISOLATION,
     OPT_VERSION,
 };
 
@@ -60,6 +61,7 @@ static struct option long_options[] = {
     {"subnet-mask",             required_argument,  0,  OPT_SUBNET_MASK},
     {"enable-tso",              no_argument,        0,  OPT_ENABLE_TSO},
     {"enable-checksum-offload", no_argument,        0,  OPT_ENABLE_CHECKSUM_OFFLOAD},
+    {"enable-isolation",        no_argument,        0,  OPT_ENABLE_ISOLATION},
     {"verbose",                 no_argument,        0,  'v'},
     {"version",                 no_argument,        0,  OPT_VERSION},
     {"help",                    no_argument,        0,  'h'},
@@ -195,6 +197,9 @@ void parse_options(struct options *opts, int argc, char **argv)
         case OPT_ENABLE_CHECKSUM_OFFLOAD:
             opts->enable_checksum_offload = true;
             break;
+        case OPT_ENABLE_ISOLATION:
+            opts->enable_isolation = true;
+            break;
         case 'v':
             verbose = true;
             break;
@@ -248,7 +253,12 @@ void parse_options(struct options *opts, int argc, char **argv)
     }
 
     if (opts->operation_mode == VMNET_BRIDGED_MODE && opts->shared_interface == NULL) {
-        ERROR("shared-interface is required for operation-mode=bridged");
+        ERROR("Missing argument: shared-interface is required for operation-mode=bridged");
+        exit(EXIT_FAILURE);
+    }
+
+    if (opts->enable_isolation && opts->operation_mode != VMNET_HOST_MODE) {
+        ERROR("Conflicting arguments: enable-isolation requires operation-mode=host");
         exit(EXIT_FAILURE);
     }
 }

--- a/options.h
+++ b/options.h
@@ -16,6 +16,7 @@ struct options {
     const char *end_address;
     const char *subnet_mask;
     const char *shared_interface;
+    bool enable_isolation;
     bool enable_tso;
     bool enable_checksum_offload;
     uid_t uid;


### PR DESCRIPTION
Vmnet provides an option to isolate vment guests. Supporting it is trivial so lets add it.

```
/*!
 * @constant vmnet_enable_isolation_key
 * Enable isolation for this interface. Interface isolation ensures that
 * network communication between multiple vmnet_interface instances is
 * not possible. */ extern const char *
vmnet_enable_isolation_key API_AVAILABLE(macos(11.0)) API_UNAVAILABLE(ios, watchos, tvos);
```

This option works only with --operation-mode host, but the limit is not documented. To get more helpful error message we fail with a clear error message if used with other modes.