### PR TITLE
List shared interfaces

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,3 +40,5 @@ jobs:
           meson compile -C repro
           ./archive.sh repro
           diffoscope build/vmnet-helper-*.tar.gz repro/vmnet-helper-*.tar.gz
+      - name: List shared interfaces
+        run: build/vmnet-helper --list-shared-interfaces

--- a/README.md
+++ b/README.md
@@ -147,6 +147,65 @@ INFO  [main] waiting for termination
 > If you want to recover from failures, restart the helper to create a
 > new unix socket and reconnect.
 
+## Operation modes
+
+The vmnet helper supports all the operation modes provided by the vmnet
+framework, using the **--operation-mode** option.
+
+### --operation-mode=host
+
+Allows the vmnet interface to communicate with other vmnet interfaces
+that are in host mode and also with the native host.
+
+Options:
+
+- **--enable-isolation**: Enable isolation for this interface. Interface
+  isolation ensures that network communication between multiple vmnet
+  interface instances is not possible.
+
+### --operation-mode=shared
+
+Allows traffic originating from the vmnet interface to reach the
+Internet through a network address translator (NAT). The vmnet interface
+can also communicate with the native host. By default, the vmnet
+interface is able to communicate with other shared mode interfaces.
+
+Options:
+
+- **--start-address**: The starting IPv4 address to use for the interface.
+  This address is used as the gateway address. The subsequent address up
+  to and including **--end-address** are placed in the DHCP pool.
+  All other addresses are available for static assignment.  The address
+  must be in the private IP range (RFC 1918).  Must be specified along
+  with **--end-address** and **--subnet-mask** (default "192.168.105.1").
+
+- **--end-address**: The DHCP IPv4 range end address (string) to use for
+  the interface.  The address must be in the private IP range (RFC
+  1918).  Must be specified with **--start-address** and
+  **--subnet-mask** (default "192.168.105.254").
+
+- **--subnet-mask**: The IPv4 subnet mask to use on the interface.  Must
+  also specify **--start-address** and **--end-address** (default
+  "255.255.255.0").
+
+### --operation-mode=bridged
+
+Bridges the vmnet interface with a physical network interface. When
+using this mode you must specify the interface name using
+**--shared-interface**.
+
+Required options:
+- **--shared-interface**: The name of the interface to use.
+
+You can find the physical interfaces that can be used in bridged more
+using the **--list-shared-interfaces** option.
+
+```console
+% /opt/vmnet-helper/bin/vmnet-helper --list-shared-interfaces
+en10
+en0
+```
+
 ## Stopping the interface
 
 Terminate the vmnet-helper process gracefully. Send a SIGTERM or SIGINT

--- a/example
+++ b/example
@@ -82,6 +82,7 @@ VMNET_OFFLOAD_AUTO = {
 
 
 def main():
+    shared_interfaces = lookup_shared_interfaces()
     p = argparse.ArgumentParser(description="Run virtual machine using vmnet-helper")
     p.add_argument("vm_name", help="VM name")
     p.add_argument(
@@ -122,7 +123,9 @@ def main():
     )
     p.add_argument(
         "--shared-interface",
-        help="vmnet shared interface, required for --operation-mode=bridged",
+        choices=shared_interfaces,
+        default=shared_interfaces[0],
+        help=f"vmnet shared interface for --operation-mode=bridged ({shared_interfaces[0]})",
     )
     p.add_argument(
         "--enable-isolation",
@@ -163,6 +166,15 @@ def main():
         run_with_fd(args)
     elif args.connection == "socket":
         run_with_socket(args)
+
+
+def lookup_shared_interfaces():
+    cp = subprocess.run(
+        ["/opt/vmnet-helper/bin/vmnet-helper", "--list-shared-interfaces"],
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    return cp.stdout.decode().splitlines()
 
 
 def terminate(signo, frame):


### PR DESCRIPTION
- Add option to list the shared interfaces that can be used in bridged mode
- Automatically use the first shared interface
- Document the available operation modes and their related options