### PR TITLE
Write vm command line to vm_home/driver.command

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -87,6 +87,7 @@ jobs:
         run: |
           vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
           ssh_cmd="ssh -o StrictHostKeyChecking=no ubuntu@$vm_ip"
+          $ssh_cmd uname -a
           $ssh_cmd sudo apt-get update -y
           $ssh_cmd sudo DEBIAN_FRONTEND=noninteractive apt-get install -y iperf3
           $ssh_cmd sudo systemctl start iperf3.service

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -77,7 +77,12 @@ jobs:
         if: always()
         run: |
           tree -h ~/.vmnet-helper
-          head -n 500 ~/.vmnet-helper/vms/test/*.log /var/db/dhcpd_leases || true
+          vm="$HOME/.vmnet-helper/vms/test"
+          vm_files=$(find "$vm" -name "*.command" -or -name "*.log")
+          for f in $vm_files /var/db/dhcpd_leases; do
+            echo "==> $f <=="
+            head -n 500 "$f" || true
+          done
       - name: Prepare example VM
         run: |
           vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -63,6 +63,7 @@ class VM:
         print(
             f"Starting '{self.driver}' virtual machine '{self.vm_name}' with mac address '{self.mac_address}'"
         )
+        self.write_command(cmd)
         store.silent_remove(self.serial)
         with open(store.vm_path(self.vm_name, f"{self.driver}.log"), "w") as log:
             pass_fds = [self.fd] if self.fd is not None else []
@@ -72,6 +73,15 @@ class VM:
         self.delete_ip_address()
         self.proc.terminate()
         self.proc.wait()
+
+    def write_command(self, cmd):
+        """
+        Write command to file to make it easy to debug and report bugs.
+        """
+        path = store.vm_path(self.vm_name, f"{self.driver}.command")
+        data = " \\\n    ".join(cmd) + "\n"
+        with open(path, "w") as f:
+            f.write(data)
 
     def wait_for_ip_address(self, timeout=300):
         """


### PR DESCRIPTION
This can help debug CI builds and reporting bugs. For example, to report qemu bugs we need the qemu command line.

Example command file:

    % cat ~/.vmnet-helper/vms/server/vfkit.command
    vfkit \
        --memory=1024 \
        --cpus=1 \
        --bootloader=efi,variable-store=/Users/nir/.vmnet-helper/vms/server/efi-variable-store,create \
        --device=usb-mass-storage,path=/Users/nir/.vmnet-helper/vms/server/cidata.iso,readonly \
        --device=virtio-blk,path=/Users/nir/.vmnet-helper/vms/server/disk.img \
        --device=virtio-serial,logFilePath=/Users/nir/.vmnet-helper/vms/server/serial.log \
        --log-level=debug \
        --device=virtio-net,fd=3,mac=92:c9:52:b7:6c:08