### PR TITLE
Skip jq install if possible

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -69,7 +69,7 @@ jobs:
           source .venv/bin/activate
           ./example test --driver ${{ matrix.driver }} --connection ${{ matrix.connection }} -v &
           vm="$HOME/.vmnet-helper/vms/test"
-          if ! timeout 5m bash -c "until test -f "$vm/ip-address"; do sleep 3; done"; then
+          if ! timeout 3m bash -c "until test -f "$vm/ip-address"; do sleep 3; done"; then
               echo >&2 "Timeout waiting for $vm/ip-address"
               exit 1
           fi

--- a/vmnet/cidata.py
+++ b/vmnet/cidata.py
@@ -67,17 +67,19 @@ def create_user_data(vm):
             "expire": False,
         },
         "ssh_authorized_keys": public_keys(),
-        "packages": [
-            "jq",
-        ],
-        "package_update": False,
-        "package_upgrade": False,
         "runcmd": [
             "ip_address=$(ip -4 -j addr show dev vmnet0 | jq -r '.[0].addr_info[0].local')",
             f"echo > {serial_console}",
             f"echo {vm.vm_name} address: $ip_address > {serial_console}",
         ],
     }
+
+    # Skip jq install if posisble to minimize startup time in the CI.
+    if vm.distro != "ubuntu":
+        data["packages"] = ["jq"]
+        data["package_update"] = False
+        data["package_upgrade"] = False
+
     path = store.vm_path(vm.vm_name, "user-data")
     with open(path, "w") as f:
         f.write("#cloud-config\n")

--- a/vmnet/disks.py
+++ b/vmnet/disks.py
@@ -45,24 +45,24 @@ IMAGES = {
 }
 
 
-def create_disk(vm_name, distro):
+def create_disk(vm):
     """
     Create a disk from image using copy-on-write.
     """
-    image_info = IMAGES[distro][platform.machine()]
-    disk = {"image": store.vm_path(vm_name, "disk.img")}
+    image_info = IMAGES[vm.distro][platform.machine()]
+    disk = {"image": store.vm_path(vm.vm_name, "disk.img")}
     if not os.path.isfile(disk["image"]):
         image = create_image(image_info["image"], format="raw", size="20g")
         print(f"Creating image '{disk['image']}'")
         clone(image, disk["image"])
     if "kernel" in image_info:
-        disk["kernel"] = store.vm_path(vm_name, "kernel")
+        disk["kernel"] = store.vm_path(vm.vm_name, "kernel")
         if not os.path.isfile(disk["kernel"]):
             kernel = create_image(image_info["kernel"])
             print(f"Creating kernel '{disk['kernel']}'")
             clone(kernel, disk["kernel"])
     if "initrd" in image_info:
-        disk["initrd"] = store.vm_path(vm_name, "initrd")
+        disk["initrd"] = store.vm_path(vm.vm_name, "initrd")
         if not os.path.isfile(disk["initrd"]):
             initrd = create_image(image_info["initrd"])
             print(f"Creating initrd '{disk['initrd']}'")

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -50,7 +50,7 @@ class VM:
         """
         Starts a VM driver with fd or socket.
         """
-        self.disk = disks.create_disk(self.vm_name, self.distro)
+        self.disk = disks.create_disk(self)
         self.cidata = cidata.create_iso(self)
         if self.driver == "vfkit":
             cmd = self.vfkit_command()

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -83,7 +83,7 @@ class VM:
         with open(path, "w") as f:
             f.write(data)
 
-    def wait_for_ip_address(self, timeout=300):
+    def wait_for_ip_address(self, timeout=180):
         """
         Lookup the vm ip address in the serial log and write to
         vm_home/ip-address.

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -51,7 +51,7 @@ class VM:
         Starts a VM driver with fd or socket.
         """
         self.disk = disks.create_disk(self.vm_name, self.distro)
-        self.cidata = cidata.create_iso(self.vm_name, self.driver, self.mac_address)
+        self.cidata = cidata.create_iso(self)
         if self.driver == "vfkit":
             cmd = self.vfkit_command()
         elif self.driver == "krunkit":


### PR DESCRIPTION
This minimize the time to start the VM in the CI, making it easier to debug startup issue, when we don't have ssh access to the guest. The time moves to the next step preparing the VM, but it is easier to debug.