### PR TITLE
Introduce vmnet-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,8 @@ MAC address on the every run.
 
 ## Starting the helper with a unix socket
 
-To use the helper from a shell script, or if the virtual machine
-driver does not support passing file descriptors, you can use a on-disk
-unix socket.
+To start the helper from a shell, or if the virtual machine driver does not
+support passing a file descriptor, you can use a bound unix socket.
 
 Example run with a unix socket, redirecting the helper stdout to file:
 
@@ -146,6 +145,27 @@ INFO  [main] waiting for termination
 > Once connected, the helper will ignore packets sent by a new client.
 > If you want to recover from failures, restart the helper to create a
 > new unix socket and reconnect.
+
+### Using vmnet-client
+
+To use the helper from a shell script without using a bound unix socket, you
+can use *vmnet-client*. The client creates a socketpair, and starts the helper
+with one socket, and the command provided by the user with the other socket.
+
+Example run with *vfkit*:
+
+```console
+/opt/vmnet-helper/bin/vmnet-client \
+    vfkit \
+    --bootloader=efi,variable-store=efi-variable-store,create \
+    "--device=virtio-blk,path=disk.img" \
+    "--device=virtio-net,fd=4,mac=92:c9:52:b7:6c:08" \
+```
+
+> [!IMPORTANT]
+> The command run by *vmnet-client* must use file descriptor 4.
+
+See the [examples](examples/) for more examples for using *vmnet-client*.
 
 ## Operation modes
 

--- a/client.c
+++ b/client.c
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: The vmnet-helper authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "config.h"
+
+// To keep it simple we always use the same file descriptor for the helper and
+// command. Inheriting additional file descriptors is not supported.
+const int HELPER_FD = 3;
+const int COMMAND_FD = 4;
+
+static void set_socket_buffers(int fd)
+{
+    // Setting socket buffer size is a performance optimization so we don't fail on
+    // errors.
+
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &SNDBUF_SIZE, sizeof(SNDBUF_SIZE)) < 0) {
+        perror("setsockopt");
+    }
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &RCVBUF_SIZE, sizeof(RCVBUF_SIZE)) < 0) {
+        perror("setsockopt");
+    }
+}
+
+static void create_socketpair(void)
+{
+    // Make sure descriptors 3 and 4 are available so socketpair() can reuse them.
+
+    close(HELPER_FD);
+    close(COMMAND_FD);
+
+    int fds[2];
+    if (socketpair(PF_LOCAL, SOCK_DGRAM, 0, fds) < 0) {
+        perror("socketpair");
+        exit(EXIT_FAILURE);
+    }
+
+    // Due to reusing first available descriptor, the descriptors should be at 3
+    // and 4. In the unliekly case when some standard descriptos are closed, we
+    // dup them to the right place. Moving fds[1] first to ensure we don't close
+    // fds[0]. If the descriptors are already in place dup2 does nothing.
+
+    if (dup2(fds[1], COMMAND_FD) < 0) {
+        perror("dup2");
+        exit(EXIT_FAILURE);
+    }
+
+    if (dup2(fds[0], HELPER_FD) < 0) {
+        perror("dup2");
+        exit(EXIT_FAILURE);
+    }
+
+    set_socket_buffers(HELPER_FD);
+    set_socket_buffers(COMMAND_FD);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "Usage: vmnet-client command ...\n");
+        exit(EXIT_FAILURE);
+    }
+
+    create_socketpair();
+
+    pid_t helper_pid = fork();
+    if (helper_pid < 0) {
+        perror("fork");
+        exit(EXIT_FAILURE);
+    }
+
+    if (helper_pid == 0) {
+        // Child: start vment-helper.
+        // We depend on sudoers configuration to allow vment-helper to run
+        // without a password and enable the closefrom_override option for this
+        // user. See sudoers.d/README.md for more info.
+        char *helper_argv[] = {
+            "sudo",
+            "--non-interactive",
+            // Allow the helper to inherit file descriptor 3.
+            "--close-from=4",
+            PREFIX "/bin/vmnet-helper",
+            "--fd=3",
+            NULL,
+        };
+        if (execvp(helper_argv[0], helper_argv) < 0) {
+            perror("execvp");
+            exit(EXIT_FAILURE);
+        }
+    } else {
+        // Parent: start the commmnad.
+        char **command_argv = argv + 1;
+        if (execvp(command_argv[0], command_argv) < 0) {
+            perror("execvp");
+            exit(EXIT_FAILURE);
+        }
+    }
+}

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: The vmnet-helper authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define PREFIX "@PREFIX@"
+
+// Apple recommends sizing the receive buffer at 4 times the size of the send
+// buffer, and other projects typically use a 1 MiB send buffer and a 4 MiB
+// receive buffer. However the send buffer size is not used to allocate a buffer
+// in datagram sockets, it only limits the maximum packet size. We use 65 KiB
+// buffer to allow the largest possible packet size (65550 bytes) when using the
+// vmnet_enable_tso option.
+static const int SNDBUF_SIZE = 65 * 1024;
+
+// The receive buffer size determines how many packets can be queued by the
+// peer. Testing shows good performance with a 2 MiB receive buffer. We use a 4
+// MiB buffer to make ENOBUFS errors less likely for the peer and allowing to
+// queue more packets when using the vmnet_enable_tso option.
+static const int RCVBUF_SIZE = 4 * 1024 * 1024;
+
+#endif // CONFIG_H

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,29 @@
+# Examples
+
+This directory contains examples for using *vmnet-helper* and
+*vmnet-client*:
+
+- [qemu.sh](#qemu.sh)
+
+> [!TIP]
+> Log in as user `ubuntu` with password `password`
+
+## qemu.sh
+
+This example shows how to start a *QEMU* virtual machine connected to a vmnet
+network interface using the vmnet-client wrapper.
+
+To start the example virtual machine run:
+
+```bash
+./qemu.sh
+```
+
+The example downloads an Ubuntu server cloud image, creates a cloud-init
+iso image, and starts a *QEMU* virtual machine with both images.
+
+## Helper scripts
+
+- `download.sh`: downloads an Ubuntu server cloud image and convert it
+  to raw format.
+- `create-iso.sh`: creates cloud-init iso image.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,7 @@ This directory contains examples for using *vmnet-helper* and
 *vmnet-client*:
 
 - [qemu.sh](#qemu.sh)
+- [vfkit.sh](#vfkit.sh)
 
 > [!TIP]
 > Log in as user `ubuntu` with password `password`
@@ -21,6 +22,21 @@ To start the example virtual machine run:
 
 The example downloads an Ubuntu server cloud image, creates a cloud-init
 iso image, and starts a *QEMU* virtual machine with both images.
+
+## vfkit.sh
+
+This example shows how to start a *vfkit* virtual machine connected to a vmnet
+network interface using the vmnet-client wrapper.
+
+To start the example virtual machine run:
+
+```bash
+./vfkit.sh
+```
+
+The example downloads an Ubuntu server cloud image, creates a cloud-init
+iso image, and starts a *vfkit* virtual machine with both images.
+
 
 ## Helper scripts
 

--- a/examples/create-iso.sh
+++ b/examples/create-iso.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Create cidata iso for examples.
+
+MAC_ADDRESS="${1:?Usage: create-iso MAC_ADDRESS [FILENAME]}"
+CIDATA_ISO="${2:-cidata.iso}"
+
+cat > user-data << EOF
+#cloud-config
+password: password
+chpasswd:
+  expire: false
+EOF
+
+cat > meta-data << EOF
+instance-id: $(uuidgen)
+local-hostname: example
+EOF
+
+cat > network-config << EOF
+version: 2
+ethernets:
+  eth0:
+    match:
+      macaddress: $MAC_ADDRESS
+    set-name: eth0
+    dhcp4: true
+    dhcp-identifier: mac
+EOF
+
+mkisofs \
+    -output "$CIDATA_ISO" \
+    -volid cidata \
+    -joliet \
+    -rock \
+    user-data meta-data network-config

--- a/examples/download.sh
+++ b/examples/download.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Download disk image for the examples.
+
+DISK_IMAGE="${1:?Usage: disk.sh FILENAME}"
+IMAGE_ARCH="arm64"
+TMP_IMAGE="$DISK_IMAGE.tmp"
+
+trap 'rm -f "$DISK_IMAGE.tmp"' EXIT
+
+# Download qcow2 cloud image.
+curl \
+    --fail \
+    --location \
+    --output "$TMP_IMAGE" \
+    "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-$IMAGE_ARCH.img"
+
+# Convert to raw so we can use this image for vfkit.
+qemu-img convert -f qcow2 -O raw "$TMP_IMAGE" "$DISK_IMAGE"

--- a/examples/qemu.sh
+++ b/examples/qemu.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Example for using vmnet-client with QEMU.
+
+MAC_ADDRESS="92:c9:52:b7:6c:08"
+DISK_IMAGE="disk.img"
+CIDATA_ISO="cidata.iso"
+
+if [ ! -f "$DISK_IMAGE" ]; then
+    ./download.sh "$DISK_IMAGE"
+fi
+
+if [ ! -f "$CIDATA_ISO" ]; then
+    ./create-iso.sh "$MAC_ADDRESS" "$CIDATA_ISO"
+fi
+
+# Start qemu and vmnet-helper connected via unix datagram sockets.
+/opt/vmnet-helper/bin/vmnet-client \
+    qemu-system-aarch64 \
+    -m 1024 \
+    -cpu host \
+    -machine virt,accel=hvf \
+    -smp 1 \
+    -drive if=pflash,format=raw,readonly=on,file=/opt/homebrew/share/qemu/edk2-aarch64-code.fd \
+    -drive "file=$DISK_IMAGE,if=virtio,format=raw" \
+    -netdev dgram,id=net1,local.type=fd,local.str=4 \
+    -device "virtio-net-pci,netdev=net1,mac=$MAC_ADDRESS" \
+    -drive "file=$CIDATA_ISO,id=cdrom0,if=none,format=raw,readonly=on" \
+    -device virtio-scsi-pci,id=scsi0 \
+    -device scsi-cd,bus=scsi0.0,drive=cdrom0 \
+    -serial stdio \
+    -nographic \
+    -nodefaults \

--- a/examples/vfkit.sh
+++ b/examples/vfkit.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Example for using vmnet-client with vfkit.
+
+MAC_ADDRESS="92:c9:52:b7:6c:08"
+DISK_IMAGE="disk.img"
+CIDATA_ISO="cidata.iso"
+
+if [ ! -f "$DISK_IMAGE" ]; then
+    ./download.sh "$DISK_IMAGE"
+fi
+
+if [ ! -f "$CIDATA_ISO" ]; then
+    ./create-iso.sh "$MAC_ADDRESS" "$CIDATA_ISO"
+fi
+
+# Start vfkit and vmnet-helper connected via unix datagram sockets.
+/opt/vmnet-helper/bin/vmnet-client \
+    vfkit \
+    --memory=1024 \
+    --cpus=1 \
+    --bootloader=efi,variable-store=efi-variable-store,create \
+    "--device=usb-mass-storage,path=$CIDATA_ISO,readonly" \
+    "--device=virtio-blk,path=$DISK_IMAGE" \
+    "--device=virtio-net,fd=4,mac=$MAC_ADDRESS" \
+    --device virtio-serial,stdio \

--- a/helper.c
+++ b/helper.c
@@ -52,15 +52,18 @@
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
-// Apple recommend receive buffer size to be 4 times the size of the send
-// buffer size, but send buffer size is not used to allocate a buffer in
-// datagram sockets, it only limits the maximum packet size.
-// Must be larger than TSO packets size (65550 bytes).
+// Apple recommends sizing the receive buffer at 4 times the size of the send
+// buffer, and other projects typically use a 1 MiB send buffer and a 4 MiB
+// receive buffer. However the send buffer size is not used to allocate a buffer
+// in datagram sockets, it only limits the maximum packet size. We use 65 KiB
+// buffer to allow the largest possible packet size (65550 bytes) when using the
+// vmnet_enable_tso option.
 static const int SNDBUF_SIZE = 65 * 1024;
 
-// The receive buffer size determine how many packets can be queued by the
-// peer. Using bigger receive buffer size make ENOBUFS error less likey for the
-// peer and improves throughput.
+// The receive buffer size determines how many packets can be queued by the
+// peer. Testing shows good performance with a 2 MiB receive buffer. We use a 4
+// MiB buffer to make ENOBUFS errors less likely for the peer and allowing to
+// queue more packets when using the vmnet_enable_tso option.
 static const int RCVBUF_SIZE = 4 * 1024 * 1024;
 
 static const uintptr_t SHUTDOWN_EVENT = 1;

--- a/helper.c
+++ b/helper.c
@@ -22,6 +22,7 @@
 #include <uuid/uuid.h>
 #include <vmnet/vmnet.h>
 
+#include "config.h"
 #include "log.h"
 #include "options.h"
 #include "socket_x.h"
@@ -51,20 +52,6 @@
 #define VM_RETRY_DELAY (50 * MICROSECOND)
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
-
-// Apple recommends sizing the receive buffer at 4 times the size of the send
-// buffer, and other projects typically use a 1 MiB send buffer and a 4 MiB
-// receive buffer. However the send buffer size is not used to allocate a buffer
-// in datagram sockets, it only limits the maximum packet size. We use 65 KiB
-// buffer to allow the largest possible packet size (65550 bytes) when using the
-// vmnet_enable_tso option.
-static const int SNDBUF_SIZE = 65 * 1024;
-
-// The receive buffer size determines how many packets can be queued by the
-// peer. Testing shows good performance with a 2 MiB receive buffer. We use a 4
-// MiB buffer to make ENOBUFS errors less likely for the peer and allowing to
-// queue more packets when using the vmnet_enable_tso option.
-static const int RCVBUF_SIZE = 4 * 1024 * 1024;
 
 static const uintptr_t SHUTDOWN_EVENT = 1;
 

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,10 @@ project(
   ],
 )
 
+config = configuration_data()
+config.set('PREFIX', get_option('prefix'))
+configure_file(input: 'config.h.in', output: 'config.h', configuration: config)
+
 version_h = vcs_tag(
   command: ['git', 'describe', '--tags'],
   input: 'version.h.in',
@@ -31,6 +35,15 @@ vmnet_helper = executable(
   install: true,
   dependencies: [
     vmnet_framework,
+    version_h_dep,
+  ],
+)
+
+vmnet_client = executable(
+  'vmnet-client',
+  'client.c',
+  install: true,
+  dependencies: [
     version_h_dep,
   ],
 )

--- a/vmnet/helper.py
+++ b/vmnet/helper.py
@@ -12,15 +12,18 @@ from . import store
 
 OPERATION_MODES = ["shared", "bridged", "host"]
 
-# Apple recommend receive buffer size to be 4 times the size of the send
-# buffer size, but send buffer size is not used to allocate a buffer in
-# datagram sockets, it only limits the maximum packet size.
-# Must be larger than TSO packets size (65550 bytes).
+# Apple recommends sizing the receive buffer at 4 times the size of the send
+# buffer, and other projects typically use a 1 MiB send buffer and a 4 MiB
+# receive buffer. However the send buffer size is not used to allocate a buffer
+# in datagram sockets, it only limits the maximum packet size. We use 65 KiB
+# buffer to allow the largest possible packet size (65550 bytes) when using the
+# vmnet_enable_tso option.
 SEND_BUFSIZE = 65 * 1024
 
-# The receive buffer size determine how many packets can be queued by the
-# peer. Using bigger receive buffer size make ENOBUFS error less likey for the
-# peer and improves throughput.
+# The receive buffer size determines how many packets can be queued by the peer.
+# Testing shows good performance with a 2 MiB receive buffer. We use a 4 MiB
+# buffer to make ENOBUFS errors less likely for the peer and allowing to queue
+# more packets when using the vmnet_enable_tso option.
 RECV_BUFSIZE = 4 * 1024 * 1024
 
 


### PR DESCRIPTION
The `vmnet-client` program makes it possible to start a VM using `QEMU` or `vfkit` from a shell script.

The client accepts `QEMU` or `vfkit` command configured to use fd 4 as connected unix datagram socket. The client creates a socketpair, starts `vmnet-helper` with one socket, and start the provided command with the other socket.

This will help users of `socket_vmnet_client`[1] to migrate to `vmnet-helper`.

The `vfkit` command can be used without `vmnet-client` with the `--socket` option. With `vmnet-client` you can use `vfkit` from the shell without creating on-disk unix socket.

The current version supports only shared mode and use random interface-id for every run. We can add command line options later to support all `vmnet-helper` features.

Status
- [x] vment-client
- [x] example
- [x] docs

Future work:
- integration tests: #70
- Command line options to support all vment-helper options
- Using the mac address returned by vmnet framework

[1] https://github.com/lima-vm/socket_vmnet/tree/master?tab=readme-ov-file#qemu

Fixes #64