### PR TITLE
Fix some copyright SPDX headers

### DIFF
--- a/benchmarks/full.yaml
+++ b/benchmarks/full.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: The vmnethelper authors
+# SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Benchmark all builtin drivers with all operation modes.

--- a/benchmarks/offloading.yaml
+++ b/benchmarks/offloading.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: The vmnethelper authors
+# SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Benchmark krunkit without offloading and vfkit with offloading.

--- a/benchmarks/quick.yaml
+++ b/benchmarks/quick.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: The vmnethelper authors
+# SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Quick benchmark for testing the bench tool.

--- a/plots/drivers.yaml
+++ b/plots/drivers.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: The vmnethelper authors
+# SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Compare vmnet-helper drivers

--- a/plots/offloading.yaml
+++ b/plots/offloading.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: The vmnethelper authors
+# SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Compare vmnet-helper drivers with offloading

--- a/plots/socket_vmnet-vms-qemu.yaml
+++ b/plots/socket_vmnet-vms-qemu.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: The vmnethelper authors
+# SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Compare socket_vmnet performance with different number of vms.

--- a/plots/socket_vmnet-vms-vz.yaml
+++ b/plots/socket_vmnet-vms-vz.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: The vmnethelper authors
+# SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Compare socket_vmnet performance with different number of vms.

--- a/plots/vmnet-helper-vs-socket_vmnet.yaml
+++ b/plots/vmnet-helper-vs-socket_vmnet.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: The vmnethelper authors
+# SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Compare vmnet-helper with socket_vmnet


### PR DESCRIPTION
The benchmarks and plots copyright were missing a `-`.