### PR TITLE
Add vmnet-client integration tests

### DIFF
--- a/.github/workflows/integration-client.yaml
+++ b/.github/workflows/integration-client.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-name: Integration
+name: Integration (client)
 
 on:
   pull_request:
@@ -19,10 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         driver: [vfkit, qemu]
-        connection: [fd, socket]
-        exclude:
-          - driver: qemu
-            connection: socket
     steps:
       - name: Host info
         run: |
@@ -60,47 +56,46 @@ jobs:
       - name: Ensure public key
         run: |
           ssh-keygen -q -N "" </dev/zero
-      - name: Create virtual env
-        run: |
-          python3 -m venv .venv
-          .venv/bin/pip install pyyaml
       - name: Start example VM
+        working-directory: examples
         run: |
-          source .venv/bin/activate
-          ./example test --driver ${{ matrix.driver }} --connection ${{ matrix.connection }} -v &
-          vm="$HOME/.vmnet-helper/vms/test"
-          if ! timeout 3m bash -c "until test -f "$vm/ip-address"; do sleep 3; done"; then
-              echo >&2 "Timeout waiting for $vm/ip-address"
+          ./${{ matrix.driver }}.sh &
+          if ! timeout 3m bash -c "until test -f ip-address; do sleep 3; done"; then
+              echo >&2 "Timeout waiting for ip-address"
               exit 1
           fi
       - name: Inspect VM host data
         if: always()
+        working-directory: examples
         run: |
-          tree -h ~/.vmnet-helper
-          vm="$HOME/.vmnet-helper/vms/test"
-          vm_files=$(find "$vm" -name "*.command" -or -name "*.log")
-          for f in $vm_files $vm/ip-address $vm/user-data $vm/meta-data $vm/network-config /var/db/dhcpd_leases; do
+          tree -h .
+          vm_files=$(find . -name "*.log")
+          for f in $vm_files ip-address user-data meta-data network-config /var/db/dhcpd_leases; do
             echo "==> $f <=="
             head -n 500 "$f" || true
           done
       - name: Inspect VM guest data
+        working-directory: examples
         run: |
-          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
+          vm_ip=$(cat ip-address)
           ssh_cmd="ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -l ubuntu $vm_ip"
           echo "uname: $($ssh_cmd uname -a)"
           echo "cmdline: $($ssh_cmd cat /proc/cmdline)"
       - name: Prepare example VM
+        working-directory: examples
         run: |
-          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
+          vm_ip=$(cat ip-address)
           ssh_cmd="ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -l ubuntu $vm_ip"
           $ssh_cmd sudo apt-get update -y
           $ssh_cmd sudo DEBIAN_FRONTEND=noninteractive apt-get install -y iperf3
           $ssh_cmd sudo systemctl start iperf3.service
       - name: Run iperf3 (host to vm)
+        working-directory: examples
         run: |
-          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
+          vm_ip=$(cat ip-address)
           iperf3-darwin -c $vm_ip
       - name: Run iperf3 (vm to host)
+        working-directory: examples
         run: |
-          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
+          vm_ip=$(cat ip-address)
           iperf3-darwin -c $vm_ip --reverse

--- a/.github/workflows/integration-helper.yaml
+++ b/.github/workflows/integration-helper.yaml
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: Integration (helper)
+
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+
+jobs:
+  example:
+    name: Example
+    # macos-15 (arm64) does not support nested virtualization yet.
+    runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        driver: [vfkit, qemu]
+        connection: [fd, socket]
+        exclude:
+          - driver: qemu
+            connection: socket
+    steps:
+      - name: Host info
+        run: |
+          uname -a
+          sw_vers
+          ifconfig
+      - name: Install requirements
+        run: brew install meson qemu cdrtools coreutils tree
+      - name: Inspect qemu
+        # Looking up both prefixes to make it eaier to port to arm64 in the future.
+        run: |
+          tree -h /usr/local/share/qemu || true
+          tree -h /opt/homebrew/share/qemu || true
+      - name: Install vfkit
+        if: matrix.driver == 'vfkit'
+        run: |
+          curl -LO https://github.com/crc-org/vfkit/releases/download/v0.6.0/vfkit
+          sudo install vfkit /usr/local/bin/
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Build vmnet-helper
+        run: |
+          meson setup build
+          meson compile -C build
+      - name: Install vmnet-helper
+        run: |
+          sudo meson install -C build
+          sudo install -m 0640 sudoers.d/vmnet-helper /etc/sudoers.d/
+      - name: Ensure bootpd is enabled
+        run: |
+          fw=/usr/libexec/ApplicationFirewall/socketfilterfw
+          sudo $fw --remove /usr/libexec/bootpd
+          sudo $fw --add /usr/libexec/bootpd
+          sudo $fw --unblock /usr/libexec/bootpd
+      - name: Ensure public key
+        run: |
+          ssh-keygen -q -N "" </dev/zero
+      - name: Create virtual env
+        run: |
+          python3 -m venv .venv
+          .venv/bin/pip install pyyaml
+      - name: Start example VM
+        run: |
+          source .venv/bin/activate
+          ./example test --driver ${{ matrix.driver }} --connection ${{ matrix.connection }} -v &
+          vm="$HOME/.vmnet-helper/vms/test"
+          if ! timeout 3m bash -c "until test -f "$vm/ip-address"; do sleep 3; done"; then
+              echo >&2 "Timeout waiting for $vm/ip-address"
+              exit 1
+          fi
+      - name: Inspect VM host data
+        if: always()
+        run: |
+          tree -h ~/.vmnet-helper
+          vm="$HOME/.vmnet-helper/vms/test"
+          vm_files=$(find "$vm" -name "*.command" -or -name "*.log")
+          for f in $vm_files $vm/ip-address $vm/user-data $vm/meta-data $vm/network-config /var/db/dhcpd_leases; do
+            echo "==> $f <=="
+            head -n 500 "$f" || true
+          done
+      - name: Inspect VM guest data
+        run: |
+          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
+          ssh_cmd="ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -l ubuntu $vm_ip"
+          echo "uname: $($ssh_cmd uname -a)"
+          echo "cmdline: $($ssh_cmd cat /proc/cmdline)"
+      - name: Prepare example VM
+        run: |
+          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
+          ssh_cmd="ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -l ubuntu $vm_ip"
+          $ssh_cmd sudo apt-get update -y
+          $ssh_cmd sudo DEBIAN_FRONTEND=noninteractive apt-get install -y iperf3
+          $ssh_cmd sudo systemctl start iperf3.service
+      - name: Run iperf3 (host to vm)
+        run: |
+          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
+          iperf3-darwin -c $vm_ip
+      - name: Run iperf3 (vm to host)
+        run: |
+          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
+          iperf3-darwin -c $vm_ip --reverse

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -79,7 +79,7 @@ jobs:
           tree -h ~/.vmnet-helper
           vm="$HOME/.vmnet-helper/vms/test"
           vm_files=$(find "$vm" -name "*.command" -or -name "*.log")
-          for f in $vm_files /var/db/dhcpd_leases; do
+          for f in $vm_files $vm/ip-address $vm/user-data $vm/meta-data $vm/network-config /var/db/dhcpd_leases; do
             echo "==> $f <=="
             head -n 500 "$f" || true
           done

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,12 @@ To start the example virtual machine run:
 The example downloads an Ubuntu server cloud image, creates a cloud-init
 iso image, and starts a *QEMU* virtual machine with both images.
 
+To connect to the vm run:
+
+```
+ssh -l ubuntu $(cat ip-address)
+```
+
 ## vfkit.sh
 
 This example shows how to start a *vfkit* virtual machine connected to a vmnet
@@ -37,6 +43,11 @@ To start the example virtual machine run:
 The example downloads an Ubuntu server cloud image, creates a cloud-init
 iso image, and starts a *vfkit* virtual machine with both images.
 
+To connect to the vm run:
+
+```
+ssh -l ubuntu $(cat ip-address)
+```
 
 ## Helper scripts
 

--- a/examples/create-iso.sh
+++ b/examples/create-iso.sh
@@ -7,26 +7,41 @@
 
 MAC_ADDRESS="${1:?Usage: create-iso MAC_ADDRESS [FILENAME]}"
 CIDATA_ISO="${2:-cidata.iso}"
+SERIAL_CONSOLE="${3:-hvc0}"
 
+# The runcmd script runs on every boot to report the IP address. The tests uses
+# this to provision the VM.
 cat > user-data << EOF
 #cloud-config
 password: password
 chpasswd:
   expire: false
+runcmd:
+- "ip_address=\$(ip -4 -j addr show dev vmnet0 | jq -r '.[0].addr_info[0].local')"
+- "echo > /dev/$SERIAL_CONSOLE"
+- "echo example address: \$ip_address > /dev/$SERIAL_CONSOLE"
+ssh_authorized_keys:
 EOF
+
+# We use the public key to provision the VM in the tests.
+for name in ~/.ssh/id_*.pub; do
+    echo "- $(cat $name)" >> user-data
+done
 
 cat > meta-data << EOF
 instance-id: $(uuidgen)
 local-hostname: example
 EOF
 
+# We rename the interface to to make it easy to find the IP address during
+# boot.
 cat > network-config << EOF
 version: 2
 ethernets:
-  eth0:
+  vmnet0:
     match:
       macaddress: $MAC_ADDRESS
-    set-name: eth0
+    set-name: vmnet0
     dhcp4: true
     dhcp-identifier: mac
 EOF

--- a/examples/download.sh
+++ b/examples/download.sh
@@ -6,8 +6,20 @@
 # Download disk image for the examples.
 
 DISK_IMAGE="${1:?Usage: disk.sh FILENAME}"
-IMAGE_ARCH="arm64"
 TMP_IMAGE="$DISK_IMAGE.tmp"
+MACHINE=$(uname -m)
+
+case "$MACHINE" in
+x86_64)
+    IMAGE_ARCH="amd64"
+    ;;
+arm64)
+    IMAGE_ARCH="arm64"
+    ;;
+*)
+    echo "Unsupported machine: $MACHINE"
+    exit 1
+esac
 
 trap 'rm -f "$DISK_IMAGE.tmp"' EXIT
 

--- a/examples/download.sh
+++ b/examples/download.sh
@@ -18,5 +18,8 @@ curl \
     --output "$TMP_IMAGE" \
     "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-$IMAGE_ARCH.img"
 
+# Resize to make room for updates.
+qemu-img resize -f qcow2 "$TMP_IMAGE" 6g
+
 # Convert to raw so we can use this image for vfkit.
 qemu-img convert -f qcow2 -O raw "$TMP_IMAGE" "$DISK_IMAGE"

--- a/examples/qemu.sh
+++ b/examples/qemu.sh
@@ -8,14 +8,18 @@
 MAC_ADDRESS="92:c9:52:b7:6c:08"
 DISK_IMAGE="disk.img"
 CIDATA_ISO="cidata.iso"
+SERIAL_CONSOLE="ttyAMA0"
 
 if [ ! -f "$DISK_IMAGE" ]; then
     ./download.sh "$DISK_IMAGE"
 fi
 
-if [ ! -f "$CIDATA_ISO" ]; then
-    ./create-iso.sh "$MAC_ADDRESS" "$CIDATA_ISO"
-fi
+# We create new iso for every run to enforce users scripts to run during
+# startup and report the IP address. This is used by the integration tests.
+./create-iso.sh "$MAC_ADDRESS" "$CIDATA_ISO" "$SERIAL_CONSOLE"
+
+# Delete data from previous run.
+rm -f serial.log ip-address
 
 # Start qemu and vmnet-helper connected via unix datagram sockets.
 /opt/vmnet-helper/bin/vmnet-client \
@@ -31,6 +35,17 @@ fi
     -drive "file=$CIDATA_ISO,id=cdrom0,if=none,format=raw,readonly=on" \
     -device virtio-scsi-pci,id=scsi0 \
     -device scsi-cd,bus=scsi0.0,drive=cdrom0 \
-    -serial stdio \
+    -serial file:serial.log \
     -nographic \
-    -nodefaults \
+    -nodefaults &
+
+if ! timeout 3m bash -c "until grep -q 'example address: ' serial.log >/dev/null; do sleep 3; done"; then
+  echo >&2 "Timeout waiting for vm IP address"
+  exit 1
+fi
+
+# Write IP address to file for the tests.
+grep 'example address: ' serial.log | cut -w -f 3 | tr -d '\r\n' > ip-address
+
+# Interrupt to terminate vfkit and vmnet-helper.
+wait

--- a/examples/vfkit.sh
+++ b/examples/vfkit.sh
@@ -8,14 +8,18 @@
 MAC_ADDRESS="92:c9:52:b7:6c:08"
 DISK_IMAGE="disk.img"
 CIDATA_ISO="cidata.iso"
+SERIAL_CONSOLE="hvc0"
 
 if [ ! -f "$DISK_IMAGE" ]; then
     ./download.sh "$DISK_IMAGE"
 fi
 
-if [ ! -f "$CIDATA_ISO" ]; then
-    ./create-iso.sh "$MAC_ADDRESS" "$CIDATA_ISO"
-fi
+# We create new iso for every run to enforce users scripts to run during
+# startup and report the IP address. This is used by the integration tests.
+./create-iso.sh "$MAC_ADDRESS" "$CIDATA_ISO" "$SERIAL_CONSOLE"
+
+# Delete data from previous run.
+rm -f serial.log ip-address
 
 # Start vfkit and vmnet-helper connected via unix datagram sockets.
 /opt/vmnet-helper/bin/vmnet-client \
@@ -26,4 +30,15 @@ fi
     "--device=usb-mass-storage,path=$CIDATA_ISO,readonly" \
     "--device=virtio-blk,path=$DISK_IMAGE" \
     "--device=virtio-net,fd=4,mac=$MAC_ADDRESS" \
-    --device virtio-serial,stdio \
+    --device=virtio-serial,logFilePath=serial.log &
+
+if ! timeout 3m bash -c "until grep -q 'example address: ' serial.log >/dev/null; do sleep 3; done"; then
+  echo >&2 "Timeout waiting for vm IP address"
+  exit 1
+fi
+
+# Write IP address to file for the tests.
+grep 'example address: ' serial.log | cut -w -f 3 | tr -d '\r\n' > ip-address
+
+# Interrupt to terminate vfkit and vmnet-helper.
+wait


### PR DESCRIPTION
Try to add integration tests using the examples scripts. This way the examples are verified, but it makes the examples too complicated.

Status:
- vfkit works
- qemu fails randomly with: `IO-APIC: timer doesn't work!`
  - Need to disable timer check like 155393a7a8224ab160d3ff2da97f5734b2834d2e

Issues:
- The examples are 2 complicated now, qemu is much worse because of x86_64 support
- Need to unify the workflows.
- Seems that using the python example is better. The example shell scripts are very simple and do not need testing.

Based on #63 
Fixes #70

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nirs/vmnet-helper/71)
<!-- Reviewable:end -->
