### PR TITLE
POC: Parse helper mac address

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,12 +39,16 @@ vmnet_helper = executable(
   ],
 )
 
+jansson_proj = subproject('jansson')
+jansson_dep = jansson_proj.get_variable('jansson_dep')
+
 vmnet_client = executable(
   'vmnet-client',
   'client.c',
   install: true,
   dependencies: [
     version_h_dep,
+    jansson_dep,
   ],
 )
 

--- a/subprojects/jansson.wrap
+++ b/subprojects/jansson.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = jansson-2.14
+source_url = https://github.com/akheron/jansson/releases/download/v2.14/jansson-2.14.tar.bz2
+source_filename = jansson-2.14.tar.bz2
+source_hash = fba956f27c6ae56ce6dfd52fbf9d20254aad42821f74fa52f83957625294afb9
+patch_filename = jansson_2.14-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/jansson_2.14-3/get_patch
+patch_hash = 8c7cdfb9a6bb575b2052fe571d65c3eb1c9eac3a99398303549b045d7a5307cb
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/jansson_2.14-3/jansson-2.14.tar.bz2
+wrapdb_version = 2.14-3
+
+[provide]
+jansson = jansson_dep


### PR DESCRIPTION
It works but we need to generate the iso with the mac address before starting vfkit. So we need to wrap vfkit with a command generating the iso with the mac address.

Ensuring that the helper was successful and failing early if the helper failed to start or could not start the vmnet interface is good and pretty simple. But the actual mac address is not that useful without a way to injecting it into cloud-init network-config.