### PR TITLE
Clean up setting socket buffers

### DIFF
--- a/client.c
+++ b/client.c
@@ -233,11 +233,14 @@ static void set_socket_buffers(int fd)
     // Setting socket buffer size is a performance optimization so we don't fail on
     // errors.
 
-    if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &SNDBUF_SIZE, sizeof(SNDBUF_SIZE)) < 0) {
-        ERRORF("setsockopt: %s", strerror(errno));
+    const int sndbuf_size = SEND_BUFFER_SIZE;
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sndbuf_size, sizeof(sndbuf_size)) < 0) {
+        WARNF("setsockopt: %s", strerror(errno));
     }
-    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &RCVBUF_SIZE, sizeof(RCVBUF_SIZE)) < 0) {
-        ERRORF("setsockopt: %s", strerror(errno));
+
+    const int rcvbuf_size = RECV_BUFFER_SIZE;
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf_size, sizeof(rcvbuf_size)) < 0) {
+        WARNF("setsockopt: %s", strerror(errno));
     }
 }
 

--- a/client.c
+++ b/client.c
@@ -25,7 +25,7 @@ const int COMMAND_FD = 4;
 
 bool verbose = false;
 
-// vmnet-helper arguments. Parsed arguemnts are appended to this list.
+// vmnet-helper arguments. Parsed arguments are appended to this list.
 // We depend on sudoers configuration to allow vment-helper to run
 // without a password and enable the closefrom_override option for this
 // user. See sudoers.d/README.md for more info.
@@ -138,7 +138,7 @@ static void validate_address(const char *arg, const char *name)
 }
 
 // Parse and validate helper arguments in argv and append to helper_argv, and
-// initialize command_argv to point ot first command argument.
+// initialize command_argv to point to first command argument.
 static void parse_options(int argc, char **argv)
 {
     const char *optname;

--- a/config.h.in
+++ b/config.h.in
@@ -12,12 +12,12 @@
 // in datagram sockets, it only limits the maximum packet size. We use 65 KiB
 // buffer to allow the largest possible packet size (65550 bytes) when using the
 // vmnet_enable_tso option.
-static const int SNDBUF_SIZE = 65 * 1024;
+#define SEND_BUFFER_SIZE (65 * 1024)
 
 // The receive buffer size determines how many packets can be queued by the
 // peer. Testing shows good performance with a 2 MiB receive buffer. We use a 4
 // MiB buffer to make ENOBUFS errors less likely for the peer and allowing to
 // queue more packets when using the vmnet_enable_tso option.
-static const int RCVBUF_SIZE = 4 * 1024 * 1024;
+#define RECV_BUFFER_SIZE (4 * 1024 * 1024)
 
 #endif // CONFIG_H

--- a/vmnet/helper.py
+++ b/vmnet/helper.py
@@ -21,13 +21,13 @@ OPERATION_MODES = ["shared", "bridged", "host"]
 # in datagram sockets, it only limits the maximum packet size. We use 65 KiB
 # buffer to allow the largest possible packet size (65550 bytes) when using the
 # vmnet_enable_tso option.
-SEND_BUFSIZE = 65 * 1024
+SEND_BUFFER_SIZE = 65 * 1024
 
 # The receive buffer size determines how many packets can be queued by the peer.
 # Testing shows good performance with a 2 MiB receive buffer. We use a 4 MiB
 # buffer to make ENOBUFS errors less likely for the peer and allowing to queue
 # more packets when using the vmnet_enable_tso option.
-RECV_BUFSIZE = 4 * 1024 * 1024
+RECV_BUFFER_SIZE = 4 * 1024 * 1024
 
 
 class Helper:
@@ -128,8 +128,8 @@ def interface_id_from(name):
 def socketpair():
     pair = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM, 0)
     for sock in pair:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, SEND_BUFSIZE)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, RECV_BUFSIZE)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, SEND_BUFFER_SIZE)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, RECV_BUFFER_SIZE)
         os.set_inheritable(sock.fileno(), True)
     return pair
 


### PR DESCRIPTION
- Rename the configuration values to SEND_BUFFER_SIZE and RECV_BUFFER_SIZE in C and python.
- Replace `const static int` with a macro in config.h.in so we don't create multiple variables in every file.
- Add set_socket_buffers() to helper.c.
- Use WARNF on failures in both client and helper.
