### PR TITLE
Fix typos

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
       - name: Ensure tag
-        # Archving requires a tag, but we checkout only the last commit.
+        # Archiving requires a tag, but we checkout only the last commit.
         run: git describe --tags 2>/dev/null || git tag devel
       - name: Install requirements
         run: brew install meson diffoscope

--- a/bench
+++ b/bench
@@ -273,7 +273,7 @@ def run(operation_mode, driver, config):
     server.start()
     try:
         # On M3 sometimes the client does not get an ip address when starting
-        # te server and client at the same time. Waiting until the server gets
+        # the server and client at the same time. Waiting until the server gets
         # an ip address before starting the client avoids this.  TODO: Until we
         # find a real fix, try to wait until the server helper is ready or a
         # short sleep.

--- a/example
+++ b/example
@@ -22,7 +22,7 @@ CONNECTION_AUTO = {
 
 VMNET_OFFLOAD_AUTO = {
     "vfkit": "off",
-    # libkrun enables offloading feautres by default, so we must enable vmnet
+    # libkrun enables offloading features by default, so we must enable vmnet
     # offloading.  See https://github.com/containers/libkrun/issues/264
     "krunkit": "on",
     "qemu": "off",

--- a/options.c
+++ b/options.c
@@ -252,7 +252,7 @@ void parse_options(struct options *opts, int argc, char **argv)
         uuid_generate_random(opts->interface_id);
     }
 
-    // When runninng via sudo we can get the real uid/gid via SUDO_*
+    // When running via sudo we can get the real uid/gid via SUDO_*
     // environment variables. When using setuid bit, getuid()/getgid() return
     // the real uid/gid.
 

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -191,7 +191,7 @@ class VM:
         if self.fd is not None:
             netdev = f"dgram,id=net1,local.type=fd,local.str={self.fd}"
         elif self.socket is not None:
-            # qemu support unix datagram socket, but it rquires local and remote sockets:
+            # qemu support unix datagram socket, but it requires local and remote sockets:
             #   -netdev dgram,id=str,local.type=unix,local.path=path[,remote.type=unix,remote.path=path]
             # The remote parameters look optional but they are required.  Trying to
             # use the helper socket with local.path and remote.path does not work.
@@ -236,7 +236,7 @@ class VM:
             "-nodefaults",
         ]
 
-        # Optinal arguments
+        # Optional arguments
 
         if "kernel" in self.disk:
             cmd.extend(["-kernel", self.disk["kernel"]])


### PR DESCRIPTION
Generated using:

    git ls-files | xargs codespell -w

And fix manually the typos that had multiple choices.