### PR TITLE
docs: Document user and group sudoers rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ password, you can install the default sudoers rule:
 sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-helper /etc/sudoers.d/
 ```
 
+See [sudoers.d](sudoers.d) for info on how to setup a sudoers rules for
+vment-helper.
+
 A simpler but less secure way is to allow any user to use vmnet-helper
 without sudo by setting the setuid bit:
 

--- a/sudoers.d/README.md
+++ b/sudoers.d/README.md
@@ -30,3 +30,52 @@ Note that to allow passing the file descriptor to the vmnet-helper
 process via sudo, you must use the `--close-from` option. This requires
 allowing the `closefrom_override` option for the user or group running
 the command.
+
+## Per-user rule
+
+If you want to allow a user not in the staff group to use vment-helper,
+create a rule for the specific user. This example allows user `alice` to
+use vmnet-helper without a password:
+
+```
+$ cat /etc/sudoers.d/vmnet-helper
+alice  ALL = (root) NOPASSWD: /opt/vmnet-helper/bin/vmnet-helper
+Defaults:alice closefrom_override
+```
+
+## Adding new group for vment-helper
+
+You can create a new "vment" group and add users to the group to allow
+them to use vment-helper without a password. This example creates the
+group "vment" and add a sudoers rule for the group:
+
+Find an available group GroupID number:
+
+```console
+dscl . list /Groups PrimaryGroupID | awk '{print $2}' | sort -n | tail -1
+701
+```
+
+We can use gid 702 for the new group.
+
+Create the new group:
+
+```console
+sudo dscl . create /Groups/vmnet
+sudo dscl . create /Groups/vmnet RealName "vment helper"
+sudo dscl . create /Groups/vmnet gid 702
+```
+
+Add the user "alice" to the group:
+
+```console
+sudo dscl . create /Groups/vmnet GroupMembership alice
+```
+
+Add a vment-helper sudoers rule for the group:
+
+```console
+$ cat /etc/sudoers.d/vmnet-helper
+%vmnet  ALL = (root) NOPASSWD: /opt/vmnet-helper/bin/vmnet-helper
+Defaults:%vmnet closefrom_override
+```


### PR DESCRIPTION
If a user is not in the staff group, they cannot use the default sudoers rule. An admin can solve this by adding a sudoers rule for a specific user, or creating a new group for vment, adding the user to the group, and adding the sudoers rule for the group.