### PR TITLE
Disable krunkit --restul-uri

### DIFF
--- a/bench
+++ b/bench
@@ -21,7 +21,6 @@ import vmnet
 SERVER = "server"
 CLIENT = "client"
 TESTS = ["host-to-vm", "vm-to-host", "vm-to-vm"]
-PORTS = {SERVER: 30000, CLIENT: 30001}
 
 
 def main():
@@ -194,8 +193,6 @@ class VM:
             f"--driver={self.driver['name']}",
             f"--operation-mode={self.operation_mode}",
         ]
-        if self.driver["name"] == "krunkit":
-            cmd.append(f"--krunkit-port={PORTS[self.name]}")
         if self.operation_mode == "bridged" and self.shared_interface:
             cmd.append(f"--shared-interface={self.shared_interface}")
         if "command" in self.driver:

--- a/example
+++ b/example
@@ -84,13 +84,6 @@ def main():
         help=f"Use custom driver command",
     )
     p.add_argument(
-        "--krunkit-port",
-        metavar="PORT",
-        type=int,
-        default=8081,
-        help="krunkit restful-uri port (8081)",
-    )
-    p.add_argument(
         "--cpus",
         metavar="N",
         type=cpus,

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -38,7 +38,6 @@ class VM:
         self.verbose = args.verbose
         self.driver = args.driver
         self.driver_command = args.driver_command
-        self.krunkit_port = args.krunkit_port
         self.cpus = args.cpus
         self.memory = args.memory
         self.distro = args.distro
@@ -179,7 +178,7 @@ class VM:
             self.driver_command or "krunkit",
             f"--memory={self.memory}",
             f"--cpus={self.cpus}",
-            f"--restful-uri=tcp://localhost:{self.krunkit_port}",
+            f"--restful-uri=none://",
             f"--device=virtio-blk,path={self.disk['image']}",
             f"--device=virtio-blk,path={self.cidata}",
             f"--device=virtio-net,unixSocketPath={self.socket},mac={self.mac_address}",


### PR DESCRIPTION
Depends on https://github.com/containers/krunkit/pull/51 adding `unix` and `none` schemes. Since we don't use the listener yet we can disable it.