### PR TITLE
build: Remove the version from the tarball

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,4 +41,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${GITHUB_REF_NAME} build/vmnet-helper-${GITHUB_REF_NAME}-*.tar.gz
+          gh release upload ${GITHUB_REF_NAME} build/vmnet-helper-*.tar.gz

--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@ running the command.
 Download and extract the vmnet-helper release archive as root:
 
 ```console
-tag="$(curl -fsSL https://api.github.com/repos/nirs/vmnet-helper/releases/latest | jq -r .tag_name)"
 machine="$(uname -m)"
-archive="vmnet-helper-$tag-$machine.tar.gz"
-curl -LOf "https://github.com/nirs/vmnet-helper/releases/download/$tag/$archive"
+archive="vmnet-helper-$machine.tar.gz"
+curl -LOf "https://github.com/nirs/vmnet-helper/releases/latest/download/$archive"
 sudo tar xvf "$archive" -C / opt/vmnet-helper
 rm "$archive"
 ```

--- a/archive.sh
+++ b/archive.sh
@@ -15,12 +15,8 @@ build_dir="${1:?Usage: $0 BUILD_DIR}"
 rm -rf "$build_dir/root"
 DESTDIR=root meson install -C "$build_dir"
 
-# v0.2.0 when building from tag (release)
-# v0.1.0-7-gb928332 when building without tag (development)
-version=$(git describe --tags)
-
 machine=$(uname -m)
-archive="$PWD/$build_dir/vmnet-helper-$version-$machine.tar"
+archive="$PWD/$build_dir/vmnet-helper-$machine.tar"
 
 # Make content reproducible by using commit time instead of build time.
 commit_time=$(git log -1 --pretty=%ct)


### PR DESCRIPTION
This simplifies downloading the latest version. We don't need to access github API to get the tag, and we can download the latest version from:

    curl -LO "https://github.com/nirs/vmnet-helper/releases/latest/download/vmnet-helper-$(uname -m).tar.gz"

The github API is failing randomly when running in github actions, so this makes it easy to install vmnet-helper in github actions.