### PR TITLE
feat: show commit sha in version output

### DIFF
--- a/client.c
+++ b/client.c
@@ -197,7 +197,7 @@ static void parse_options(int argc, char **argv)
             append_helper_arg("--verbose");
             break;
         case OPT_VERSION:
-            printf("%s\n", GIT_VERSION);
+            printf("%s\n%s\n", GIT_VERSION, GIT_COMMIT_SHA);
             exit(0);
         case ':':
             ERRORF("Option %s requires an argument", optname);

--- a/meson.build
+++ b/meson.build
@@ -17,11 +17,23 @@ config = configuration_data()
 config.set('PREFIX', get_option('prefix'))
 configure_file(input: 'config.h.in', output: 'config.h', configuration: config)
 
-version_h = vcs_tag(
-  command: ['git', 'describe', '--tags'],
+git_version = run_command('git', 'describe', '--tags', check: false).stdout().strip()
+if git_version == ''
+  git_version = 'devel'
+endif
+
+git_commit = run_command('git', 'rev-parse', 'HEAD', check: false).stdout().strip()
+if git_commit == ''
+  git_commit = 'unknown'
+endif
+
+version_conf = configuration_data()
+version_conf.set('GIT_VERSION', git_version)
+version_conf.set('GIT_COMMIT_SHA', git_commit)
+version_h = configure_file(
   input: 'version.h.in',
   output: 'version.h',
-  fallback: 'devel',
+  configuration: version_conf,
 )
 
 version_h_dep = declare_dependency(sources: [version_h])

--- a/options.c
+++ b/options.c
@@ -226,7 +226,7 @@ void parse_options(struct options *opts, int argc, char **argv)
             verbose = true;
             break;
         case OPT_VERSION:
-            printf("%s\n", GIT_VERSION);
+            printf("%s\n%s\n", GIT_VERSION, GIT_COMMIT_SHA);
             exit(0);
         case ':':
             ERRORF("Option %s requires an argument", optname);

--- a/version.h.in
+++ b/version.h.in
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: The vmnet-helper authors
 // SPDX-License-Identifier: Apache-2.0
 
-#define GIT_VERSION "@VCS_TAG@"
+#define GIT_VERSION "@GIT_VERSION@"
+#define GIT_COMMIT_SHA "@GIT_COMMIT_SHA@"


### PR DESCRIPTION
## Summary
- include commit hash in generated version header
- print commit hash alongside version for `vmnet-helper` and `vmnet-client`


# Before this PR
```
$ ./build/vmnet-helper --version
v0.7.0-pre1
```

# After this PR
```
$ ./build/vmnet-helper --version
v0.7.0-pre1-1-gf8b88a8
f8b88a8816b0db00108adb7c4a7f530ced9a5f9e
```