### PR TITLE
Report commit hash in --version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,5 +42,7 @@ jobs:
           diffoscope build/vmnet-helper-*.tar.gz repro/vmnet-helper-*.tar.gz
       - name: List shared interfaces
         run: build/vmnet-helper --list-shared-interfaces
+      - name: Print version
+        run: build/vmnet-helper --version
       - name: Check spelling
         run: meson test -C build codespell

--- a/client.c
+++ b/client.c
@@ -197,7 +197,7 @@ static void parse_options(int argc, char **argv)
             append_helper_arg("--verbose");
             break;
         case OPT_VERSION:
-            printf("%s\n", GIT_VERSION);
+            printf("version: %s\ncommit: %s\n", GIT_VERSION, GIT_COMMIT);
             exit(0);
         case ':':
             ERRORF("Option %s requires an argument", optname);

--- a/gen-version
+++ b/gen-version
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import sys
+
+
+def run(*args):
+    try:
+        return subprocess.check_output(args).decode().strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Failed: {args}: {e}", file=sys.stderr)
+        return "unknown"
+
+
+def read_output():
+    try:
+        with open(output) as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""
+
+
+def write_output(content):
+    print(f"writing {output}")
+    with open(output, "w") as f:
+        f.write(content)
+
+
+# meson @OUTPUT@
+output = sys.argv[1]
+
+version = run("git", "describe", "--tags")
+commit = run("git", "rev-parse", "HEAD")
+
+content = f"""\
+#define GIT_VERSION "{version}"
+#define GIT_COMMIT  "{commit}"
+"""
+
+# Update only if content changed to avoid unnecessary rebuilds.
+if content != read_output():
+    write_output(content)

--- a/meson.build
+++ b/meson.build
@@ -17,11 +17,12 @@ config = configuration_data()
 config.set('PREFIX', get_option('prefix'))
 configure_file(input: 'config.h.in', output: 'config.h', configuration: config)
 
-version_h = vcs_tag(
-  command: ['git', 'describe', '--tags'],
-  input: 'version.h.in',
+gen_version = find_program('gen-version')
+version_h = custom_target(
+  'version.h',
   output: 'version.h',
-  fallback: 'devel',
+  command: [gen_version, '@OUTPUT@'],
+  build_always_stale: true,
 )
 
 version_h_dep = declare_dependency(sources: [version_h])

--- a/options.c
+++ b/options.c
@@ -226,7 +226,7 @@ void parse_options(struct options *opts, int argc, char **argv)
             verbose = true;
             break;
         case OPT_VERSION:
-            printf("%s\n", GIT_VERSION);
+            printf("version: %s\ncommit: %s\n", GIT_VERSION, GIT_COMMIT);
             exit(0);
         case ':':
             ERRORF("Option %s requires an argument", optname);

--- a/version.h.in
+++ b/version.h.in
@@ -1,4 +1,0 @@
-// SPDX-FileCopyrightText: The vmnet-helper authors
-// SPDX-License-Identifier: Apache-2.0
-
-#define GIT_VERSION "@VCS_TAG@"


### PR DESCRIPTION
Using custom_target() running gen-version at build time. The script runs on every build, but writes build/version.h only if the file needs an update, avoiding unnecessary rebuilds.

Example run:

    % build/vmnet-helper --version
    version: v0.7.0-pre1-1-ga253655
    commit: a253655c2cba41266ea6f041ae9efdbadc816cd4

Scripts can use yq to extract the needed info:

    % build/vmnet-helper --version | yq .version
    v0.7.0-pre1-1-ga253655

Fixes: #96
Thanks: Medya Ghazizadeh <medya.gh@gmail.com>