### PR TITLE
example: Update to Ubuntu 25.04

### DIFF
--- a/vmnet/disks.py
+++ b/vmnet/disks.py
@@ -8,14 +8,16 @@ import subprocess
 
 from . import store
 
+UBUNTU_RELEASE = "25.04"
+
 IMAGES = {
     "ubuntu": {
         "arm64": {
-            "image": "https://cloud-images.ubuntu.com/releases/25.04/release/ubuntu-25.04-server-cloudimg-arm64.img",
+            "image": f"https://cloud-images.ubuntu.com/releases/{UBUNTU_RELEASE}/release/ubuntu-{UBUNTU_RELEASE}-server-cloudimg-arm64.img",
         },
         "x86_64": {
-            "image": "https://cloud-images.ubuntu.com/releases/25.04/release/ubuntu-25.04-server-cloudimg-amd64.img",
-            "kernel": "https://cloud-images.ubuntu.com/releases/25.04/release/unpacked/ubuntu-25.04-server-cloudimg-amd64-vmlinuz-generic",
+            "image": f"https://cloud-images.ubuntu.com/releases/{UBUNTU_RELEASE}/release/ubuntu-{UBUNTU_RELEASE}-server-cloudimg-amd64.img",
+            "kernel": f"https://cloud-images.ubuntu.com/releases/{UBUNTU_RELEASE}/release/unpacked/ubuntu-{UBUNTU_RELEASE}-server-cloudimg-amd64-vmlinuz-generic",
             # Based on the default kernel cmdline when not using kernel and initrd:
             # BOOT_IMAGE=/vmlinuz-6.11.0-14-generic root=LABEL=cloudimg-rootfs ro console=tty1 console=ttyS0
             "kernel_parameters": [
@@ -29,7 +31,7 @@ IMAGES = {
                 # https://github.com/lima-vm/socket_vmnet/pull/56
                 "no_timer_check",
             ],
-            "initrd": "https://cloud-images.ubuntu.com/releases/25.04/release/unpacked/ubuntu-25.04-server-cloudimg-amd64-initrd-generic",
+            "initrd": f"https://cloud-images.ubuntu.com/releases/{UBUNTU_RELEASE}/release/unpacked/ubuntu-{UBUNTU_RELEASE}-server-cloudimg-amd64-initrd-generic",
         },
     },
     "alpine": {


### PR DESCRIPTION
Installing ubuntu 24.10 in the CI fails now with:

    Ign:1 http://archive.ubuntu.com/ubuntu oracular InRelease
    Ign:2 http://archive.ubuntu.com/ubuntu oracular-updates InRelease
    Ign:3 http://archive.ubuntu.com/ubuntu oracular-backports InRelease
    Err:4 http://archive.ubuntu.com/ubuntu oracular Release
      404  Not Found [IP: 91.189.91.81 80]
    Ign:5 http://security.ubuntu.com/ubuntu oracular-security InRelease
    Err:6 http://archive.ubuntu.com/ubuntu oracular-updates Release
      404  Not Found [IP: 91.189.91.81 80]
    Err:7 http://archive.ubuntu.com/ubuntu oracular-backports Release
      404  Not Found [IP: 91.189.91.81 80]
    Err:8 http://security.ubuntu.com/ubuntu oracular-security Release
      404  Not Found [IP: 185.125.190.39 80]
    Reading package lists...
    E: The repository 'http://archive.ubuntu.com/ubuntu oracular Release' no longer has a Release file.
    E: The repository 'http://archive.ubuntu.com/ubuntu oracular-updates Release' no longer has a Release file.
    E: The repository 'http://archive.ubuntu.com/ubuntu oracular-backports Release' does not have a Release file.
    E: The repository 'http://security.ubuntu.com/ubuntu oracular-security Release' no longer has a Release file.