### PR TITLE
docs: Update installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,9 @@ running the command.
 Download and extract the vmnet-helper release archive as root:
 
 ```console
-machine="$(uname -m)"
-archive="vmnet-helper-$machine.tar.gz"
-curl -LOf "https://github.com/nirs/vmnet-helper/releases/latest/download/$archive"
-sudo tar xvf "$archive" -C / opt/vmnet-helper
-rm "$archive"
+curl -fsSLO "https://github.com/nirs/vmnet-helper/releases/latest/download/vmnet-helper.tar.gz"
+sudo tar xvf vmnet-helper.tar.gz -C / opt/vmnet-helper
+rm vmnet-helper.tar.gz
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
For the next release we have a single tarball for arm64 and x86_64 so we can simplify installation.

This must be merged when the release is marked latest to avoid breaking users copying the URL from the README.