### PR TITLE
example: Streamline ssh login

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,20 @@ Virtual machine IP address:  192.168.105.2
 
 To stop the virtual machine and the vmnet-helper press *Control+C*.
 
+### SSH configuration
+
+To configure ssh for the test vms add this to your `.ssh/config`:
+
+```
+Include ~/.vmnet-helper/vms/*/ssh.config
+```
+
+With this configuration you can login to the example vm with:
+
+```console
+ssh vm
+```
+
 ## Performance
 
 We benchmarked vmnet-helper with 3 VMs types (vfkit, krunkit, qemu) in

--- a/vmnet/ssh.py
+++ b/vmnet/ssh.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+from . import store
+
+
+def config_path(vm):
+    return store.vm_path(vm.vm_name, "ssh.config")
+
+
+def create_config(vm):
+    data = f"""
+Host {vm.vm_name}
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  User {vm.distro}
+  Hostname {vm.ip_address}
+"""
+    path = config_path(vm)
+    with open(path, "w") as f:
+        f.write(data)
+
+
+def delete_config(vm):
+    path = config_path(vm)
+    store.silent_remove(path)


### PR DESCRIPTION
Create ssh.config when starting vm with the VM IP address and user name and ssh configuration to avoid checking host keys and adding them to known hosts file.

With this change if you create a virtual machine with:

    % ./example server
    Starting vmnet-helper for 'server' with interface id 'bdc7b3e0-8594-4814-aa25-05187ad2a36e'
    Creating cloud-init iso '/Users/nir/.vmnet-helper/vms/server/cidata.iso'
    Starting 'vfkit' virtual machine 'server' with mac address '92:c9:52:b7:6c:08'
    Virtual machine IP address: 192.168.105.2

You can login to the virtual machine with:

    % ssh server
    Warning: Permanently added '192.168.105.2' (ED25519) to the list of known hosts.
    Welcome to Ubuntu 25.04 (GNU/Linux 6.14.0-27-generic aarch64)
    ...
    ubuntu@server:~$