### PR TITLE
ci: Switch to macos-15-intel

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -48,12 +48,6 @@ jobs:
         run: |
           sudo tar xvf build/vmnet-helper.tar.gz -C / opt/vmnet-helper
           sudo install -m 0640 /opt/vmnet-helper/share/doc/vmnet-helper/sudoers.d/vmnet-helper /etc/sudoers.d/
-      - name: Ensure bootpd is enabled
-        run: |
-          fw=/usr/libexec/ApplicationFirewall/socketfilterfw
-          sudo $fw --remove /usr/libexec/bootpd
-          sudo $fw --add /usr/libexec/bootpd
-          sudo $fw --unblock /usr/libexec/bootpd
       - name: Ensure public key
         run: |
           ssh-keygen -q -N "" </dev/zero

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -13,8 +13,9 @@ on:
 jobs:
   example:
     name: Example
-    # macos-15 (arm64) does not support nested virtualization yet.
-    runs-on: macos-13
+    # macos-15 (arm64) is using M1 cpus but nested virtualization require M3 or
+    # later.
+    runs-on: macos-15-intel
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   example:
     name: Example
-    # macos-15 (arm64) is using M1 cpus but nested virtualization require M3 or
+    # macos-26 (arm64) is using M1 cpu but nested virtualization require M3 or
     # later.
     runs-on: macos-15-intel
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   release:
     name: Release artifacts
-    runs-on: macos-15
+    runs-on: macos-26
     permissions:
       contents: write
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: Build
-    # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for--private-repositories
+    # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
     runs-on: macos-15 # arm64
     steps:
       - name: Checkout source

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: Build
     # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-    runs-on: macos-15 # arm64
+    runs-on: macos-26 # arm64
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
We don't expect these runners to be better than macos-13, but macos-13
runners are closing down soon:
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

For other workflows using macos-15 we use now macos-26.