### PR TITLE
Add virtio-rng device to avoid boot delays

### DIFF
--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -163,6 +163,7 @@ class VM:
             f"--device=virtio-blk,path={self.disk['image']}",
             f"--device=virtio-serial,logFilePath={self.serial}",
             "--log-level=debug",
+            "--device=virtio-rng",
         ]
         if self.fd is not None:
             cmd.append(f"--device=virtio-net,fd={self.fd},mac={self.mac_address}")
@@ -184,6 +185,7 @@ class VM:
             f"--device=virtio-blk,path={self.cidata}",
             f"--device=virtio-serial,logFilePath={self.serial}",
             "--krun-log-level=3",
+            "--device=virtio-rng",
         ]
 
         offloading = "on" if self.enable_offloading else "off"
@@ -247,6 +249,8 @@ class VM:
             f"file:{self.serial}",
             "-nographic",
             "-nodefaults",
+            "-device",
+            "virtio-rng-pci"
         ]
 
         # Optional arguments


### PR DESCRIPTION
VMs do not have lot of entropy sources and may have delays during boot due to lack of entropy. Adding a virtio-rng device may help to inject entropy into the vm.