### PR TITLE
integration: Wait for iper3 service

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -87,6 +87,14 @@ jobs:
           $ssh_cmd sudo apt-get update -y
           $ssh_cmd sudo DEBIAN_FRONTEND=noninteractive apt-get install -y iperf3
           $ssh_cmd sudo systemctl start iperf3.service
+          echo "Waiting for iperf3 server ..."
+          $ssh_cmd bash -s << EOF
+            if ! timeout 10s bash -c "until ss -tln | grep -q :5201; do sleep 1; done"; then
+              echo >&2 "Timeout waiting for iperf3 port"
+              exit 1
+            fi
+          EOF
+          echo "iperf3 server is ready"
       - name: Run iperf3 (host to vm)
         run: |
           vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)


### PR DESCRIPTION
We have random failure to connect to iperf3 after we start the service.

Turns out that iperf3 is using the `simple` service type:

    $ sudo systemctl show iperf3 | grep ^Type=
    Type=simple

In this case `systemctl start iperf3` does not wait for the service to signal that it is ready to handle requests or has finished initializing, so we may return before the service is ready to serve requests.

We wait not until iperf3 port is in listening state.