### PR TITLE
example: Improve logging

### DIFF
--- a/example
+++ b/example
@@ -8,6 +8,7 @@ Run a vm with vmnet-helper.
 """
 
 import argparse
+import logging
 import os
 import signal
 import sys
@@ -22,6 +23,7 @@ VMNET_OFFLOAD_AUTO = {
 
 
 def main():
+    setup_logging()
     shared_interfaces = vmnet.shared_interfaces()
     p = argparse.ArgumentParser(description="Run virtual machine using vmnet-helper")
 
@@ -152,6 +154,19 @@ def main():
         run_with_socket(args)
     elif args.connection == "client":
         run_with_client(args)
+
+
+class SecondsFormatter(logging.Formatter):
+    def format(self, record):
+        record.seconds = record.relativeCreated / 1000.0
+        return super().format(record)
+
+
+def setup_logging():
+    formatter = SecondsFormatter('[%(seconds)8.3f] %(levelname)s %(message)s')
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(formatter)
+    logging.basicConfig(handlers=[handler], level=logging.INFO)
 
 
 def run_with_fd(args):

--- a/vmnet/cidata.py
+++ b/vmnet/cidata.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import glob
+import logging
 import os
 import platform
 import subprocess
@@ -45,7 +46,7 @@ def create_iso(vm):
         "meta-data",
         "network-config",
     ]
-    print(f"Creating cloud-init iso '{cidata}'")
+    logging.info("Creating cloud-init iso '%s'", cidata)
     subprocess.run(
         cmd,
         check=True,

--- a/vmnet/disks.py
+++ b/vmnet/disks.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
+import logging
 import os
 import platform
 import subprocess
@@ -55,19 +56,19 @@ def create_disk(vm):
     disk = {"image": store.vm_path(vm.vm_name, "disk.img")}
     if not os.path.isfile(disk["image"]):
         image = create_image(image_info["image"], format="raw", size="20g")
-        print(f"Creating image '{disk['image']}'")
+        logging.info("Creating image '%s'", disk["image"])
         clone(image, disk["image"])
     if "kernel" in image_info:
         disk["kernel"] = store.vm_path(vm.vm_name, "kernel")
         if not os.path.isfile(disk["kernel"]):
             kernel = create_image(image_info["kernel"])
-            print(f"Creating kernel '{disk['kernel']}'")
+            logging.info("Creating kernel '%s'", disk["kernel"])
             clone(kernel, disk["kernel"])
     if "initrd" in image_info:
         disk["initrd"] = store.vm_path(vm.vm_name, "initrd")
         if not os.path.isfile(disk["initrd"]):
             initrd = create_image(image_info["initrd"])
-            print(f"Creating initrd '{disk['initrd']}'")
+            logging.info("Creating initrd '%s'", disk["initrd"])
             clone(initrd, disk["initrd"])
     if "kernel_parameters" in image_info:
         disk["kernel_parameters"] = image_info["kernel_parameters"]
@@ -98,7 +99,7 @@ def create_image(url, format=None, size=None):
 
 
 def download_image(image_url, path):
-    print(f"Downloading image '{image_url}'")
+    logging.info("Downloading image '%s'", image_url)
     cmd = [
         "curl",
         "--fail",
@@ -112,13 +113,13 @@ def download_image(image_url, path):
 
 
 def convert_image(src, target, format):
-    print(f"Converting image to '{format}' format '{target}'")
+    logging.info("Converting image to '%s' format '%s'", format, target)
     cmd = ["qemu-img", "convert", "-f", "qcow2", "-O", format, src, target]
     subprocess.run(cmd, check=True)
 
 
 def resize_image(path, size):
-    print(f"Resizing image to {size}")
+    logging.info("Resizing image to %s", size)
     cmd = ["qemu-img", "resize", "-q", "-f", "raw", path, size]
     subprocess.run(cmd, check=True)
 

--- a/vmnet/helper.py
+++ b/vmnet/helper.py
@@ -3,6 +3,7 @@
 
 import hashlib
 import json
+import logging
 import os
 import socket
 import subprocess
@@ -54,8 +55,10 @@ class Helper:
         Starts vmnet-helper with fd or socket.
         """
         interface_id = interface_id_from(self.vm_name)
-        print(
-            f"Starting vmnet-helper for '{self.vm_name}' with interface id '{interface_id}'"
+        logging.info(
+            "Starting vmnet-helper for '%s' with interface id '%s'",
+            self.vm_name,
+            interface_id,
         )
         if self.fd is not None:
             cmd = [

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import os
 import platform
 import selectors
@@ -68,8 +69,11 @@ class VM:
             cmd = self.qemu_command()
         else:
             raise ValueError(f"Invalid driver '{self.driver}'")
-        print(
-            f"Starting '{self.driver}' virtual machine '{self.vm_name}' with mac address '{self.mac_address}'"
+        logging.info(
+            "Starting '%s' virtual machine '%s' with mac address '%s'",
+            self.driver,
+            self.vm_name,
+            self.mac_address,
         )
         store.silent_remove(self.serial)
         self._start_process(cmd)
@@ -130,12 +134,12 @@ class VM:
             self.check_running()
             if line.startswith(prefix):
                 self.ip_address = line[len(prefix) :]
-                print(f"Virtual machine IP address: {self.ip_address}")
+                logging.info("Virtual machine IP address: %s", self.ip_address)
                 self.write_ip_address()
                 ssh.create_config(self)
                 return
         self.check_running()
-        print("Timeout looking up ip address")
+        logging.warning("Timeout looking up ip address")
 
     def check_running(self):
         if self.proc.poll() is not None:
@@ -250,7 +254,7 @@ class VM:
             "-nographic",
             "-nodefaults",
             "-device",
-            "virtio-rng-pci"
+            "virtio-rng-pci",
         ]
 
         # Optional arguments
@@ -277,6 +281,7 @@ class VM:
         cmd.append("--")
         cmd.extend(vm_command)
         return cmd
+
 
 def qemu_firmware(arch):
     """


### PR DESCRIPTION
Use logging instead of print for logging time since start.

Example first run:

    % ./example server
    [   0.047] INFO Starting vmnet-helper for 'server' with interface id 'bdc7b3e0-8594-4814-aa25-05187ad2a36e'
    [   0.345] INFO Downloading image 'https://cloud-images.ubuntu.com/releases/25.04/release/ubuntu-25.04-server-cloudimg-arm64.img'
    [  17.840] INFO Converting image to 'raw' format '/Users/nir/.vmnet-helper/cache/images/7fef961f75d830af5d20db6da02bff7e33ce662a49bd4b433ed8f35a9f6a18c0/data'
    [  20.443] INFO Resizing image to 20g 
    [  20.474] INFO Creating image '/Users/nir/.vmnet-helper/vms/server/disk.img'
    [  20.482] INFO Creating cloud-init iso '/Users/nir/.vmnet-helper/vms/server/cidata.iso'
    [  20.494] INFO Starting 'vfkit' virtual machine 'server' with mac address '92:c9:52:b7:6c:08'
    [  28.479] INFO Virtual machine IP address: 192.168.105.2

Example second run, using cached image:

    % ./example server
    [   0.044] INFO Starting vmnet-helper for 'server' with interface id 'bdc7b3e0-8594-4814-aa25-05187ad2a36e'
    [   0.212] INFO Creating cloud-init iso '/Users/nir/.vmnet-helper/vms/server/cidata.iso'
    [   0.222] INFO Starting 'vfkit' virtual machine 'server' with mac address '92:c9:52:b7:6c:08'
    [   6.476] INFO Virtual machine IP address: 192.168.105.2
