### PR TITLE
workfows: Fix permissions

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -10,6 +10,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   example:
     name: Example

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release artifacts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Add read permissions for all workflows. Jobs that need more permissions define the needed permissions.

Fixes #111 