### PR TITLE
build: Fix x86_64 macos SDK version

### DIFF
--- a/x86_64.ini
+++ b/x86_64.ini
@@ -12,5 +12,5 @@ c = 'clang'
 strip = 'strip'
 
 [built-in options]
-c_args = ['-target', 'arm64-apple-macos13.0', '-arch', 'x86_64']
-c_link_args = ['-target', 'arm64-apple-macos13.0', '-arch', 'x86_64']
+c_args = ['-target', 'arm64-apple-macos14.0', '-arch', 'x86_64']
+c_link_args = ['-target', 'arm64-apple-macos14.0', '-arch', 'x86_64']


### PR DESCRIPTION
This change was missing in #110. With this change we actually drop macOS 13 on x86_64.