### PR TITLE
Add LICENSE symlink for github compatibility

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+LICENSES/Apache-2.0.txt


### PR DESCRIPTION
GitHub expects a LICENSE file at the root directory. Add a symlink to make github happy and make the LICENSE clear in GitHub UI.

Fixes #131 