### PR TITLE
Install vmnet-broker in CI for macOS 26 tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,9 @@ jobs:
         run: build/vmnet-helper --version
       - name: Install vmnet-helper
         run: VMNET_INTERACTIVE=0 ./install.sh build/vmnet-helper.tar.gz
+      - name: Install vmnet-broker
+        if: matrix.os == 'macos-26'
+        run: curl -fsSL https://github.com/nirs/vmnet-broker/releases/latest/download/install.sh | sudo bash
       - name: Create virtual env
         run: |
           python3 -m venv .venv


### PR DESCRIPTION
Install vmnet-broker from latest release on macOS-26 runner to enable --network mode tests.

## Test Results

### By Runner

| Runner | Before | After |
|--------|--------|-------|
| macos-14 | 8 passed | 8 passed |
| macos-15 | 8 passed | 8 passed |
| macos-15-intel | 8 passed | 8 passed |
| macos-26 | 8 passed, 5 skipped | 13 passed |

### macOS 26 Details

| Test Class | Before | After |
|------------|--------|-------|
| TestStart (5) | passed | passed |
| TestConnectivity (3) | passed | passed |
| TestNetworkStart (2) | skipped | passed |
| TestNetworkConnectivity (3) | skipped | passed |