### PR TITLE
ci: Give Test workflow priority over Integration

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -5,17 +5,17 @@
 name: Integration
 
 on:
-  pull_request:
-  push:
-    branches:
-    - main
+  # Start after Test workflow begins running, giving it priority for runners.
+  workflow_run:
+    workflows: ["Test"]
+    types: [in_progress]
   schedule:
     - cron: '0 3 * * 0' # Runs job at 3AM every sunday
 
 # Cancel in-progress workflow when PR is updated.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: ${{ github.event.workflow_run.event == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Use `workflow_run` trigger with `in_progress` type so Integration starts
  only after Test is running
- This ensures Test claims runners first, avoiding delays when runners are busy
- Update concurrency group to use `workflow_run` context for correct branch
  identification and cancellation

## Test plan

- [ ] Verify Test workflow starts first when pushing to a PR
- [ ] Verify Integration workflow starts after Test is in progress
- [ ] Verify concurrency cancellation works when pushing multiple times to a PR