### PR TITLE
ci: Use reusable workflow for Integration to give Test priority

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -5,17 +5,7 @@
 name: Integration
 
 on:
-  pull_request:
-  push:
-    branches:
-    - main
-  schedule:
-    - cron: '0 3 * * 0' # Runs job at 3AM every sunday
-
-# Cancel in-progress workflow when PR is updated.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  workflow_call:  # Can be called from other workflows
 
 permissions:
   contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,11 @@ on:
   schedule:
     - cron: '0 3 * * 0' # runs job at 3AM every sunday
 
+# Cancel in-progress workflow when PR is updated.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -54,6 +59,11 @@ jobs:
         run: |
           source .venv/bin/activate
           pytest -v --log-cli-level=INFO
+
+  integration:
+    needs: test
+    if: ${{ !cancelled() }}  # Run even if test failed, skip if cancelled
+    uses: ./.github/workflows/integration.yaml
 
   reproducibility:
     name: Reproducibility


### PR DESCRIPTION
Convert integration.yaml to a reusable workflow that is called from test.yaml. This ensures Test jobs get runners first and Integration runs after Test completes, providing fast feedback from quick tests (~1 min) before slow integration tests (~6 min) start.

Changes:
- Add workflow_call trigger to integration.yaml to make it callable
- Remove pull_request, push, and schedule triggers from integration.yaml since it's now called from test.yaml for all events
- Move concurrency directive from integration.yaml to test.yaml to handle cancellation when PRs are updated
- Add integration job to test.yaml with needs: test dependency
- Position integration job right after test job for better organization

Benefits:
- Test claims runners first, Integration waits until Test completes
- Re-running the workflow re-runs both (expected behavior)
- No unexpected workflow triggers
- Integration can still run independently via workflow_call if needed
- Concurrency control ensures old integration tests are cancelled when PRs are updated

Fixes #162