### PR TITLE
helper: Warn when --interface-id is used with --network

### DIFF
--- a/helper.c
+++ b/helper.c
@@ -416,6 +416,10 @@ static vmnet_network_ref acquire_network_from_broker(void)
 // Start interface with a network.
 static void start_interface_with_network(vmnet_network_ref ref)
 {
+    if (!uuid_is_null(options.interface_id)) {
+        WARN("[main] --interface-id is ignored with --network");
+    }
+
     struct network net;
     network_from_ref(ref, &net);
 


### PR DESCRIPTION
In --network mode, vmnet ignores vmnet_interface_id_key and generates a random MAC address on every start. Warn the user so they can stop relying on --interface-id for a stable MAC and generate one from the VM name instead.

Example:

    % vmnet-helper --network shared --interface-id $(uuidgen) \
        --socket /tmp/vmnet-helper.sock
    INFO  [main] running vmnet-helper v0.10.0 on macOS 26.2.0
    ...
    WARN  [main] --interface-id is ignored with --network