### PR TITLE
example: Use public DNS servers in VM network config

### DIFF
--- a/example
+++ b/example
@@ -138,6 +138,14 @@ def main():
         help=f"Linux distro ({distros[0]})",
     )
 
+    p.add_argument(
+        "--dns-servers",
+        metavar="ADDR",
+        type=ip_list,
+        default=["8.8.8.8", "1.1.1.1"],
+        help="Comma-separated DNS servers for the VM (8.8.8.8,1.1.1.1)",
+    )
+
     # Debugging
 
     p.add_argument("-v", "--verbose", action="store_true", help="Be more verbose")
@@ -259,6 +267,11 @@ def run_with_client(args):
         os.wait()
     finally:
         vm.stop()
+
+
+def ip_list(s):
+    # TODO: validate that values are IP addresses.
+    return s.split(",")
 
 
 def cpus(s):

--- a/vmnet/cidata.py
+++ b/vmnet/cidata.py
@@ -126,7 +126,7 @@ def create_network_config(vm):
                     "use-dns": False,
                 },
                 "nameservers": {
-                    "addresses": ["8.8.8.8", "1.1.1.1"],
+                    "addresses": vm.dns_servers,
                 },
             },
         },

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -42,6 +42,7 @@ class VM:
         self.cpus = args.cpus
         self.memory = args.memory
         self.distro = args.distro
+        self.dns_servers = args.dns_servers
         self.serial = store.vm_path(self.vm_name, "serial.log")
         self.enable_offloading = args.enable_offloading
 


### PR DESCRIPTION
On managed Macs, corporate network extensions block DNS traffic from the vmnet bridge to the host's resolver (mDNSResponder), causing DNS lookups in the VM to fail. This also prevents installing avahi-daemon, breaking mDNS-based IP discovery.

Use 8.8.8.8 and 1.1.1.1 as static nameservers and disable DHCP-provided DNS, since the macOS host DNS cannot be trusted.

The dns servers can be changed using new --dns-server= option.