### PR TITLE
example: Enable krunkit debug logs with --verbose

### DIFF
--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -201,6 +201,7 @@ class VM:
         return cmd
 
     def krunkit_command(self):
+        log_level = "4" if self.verbose else "3"
         cmd = [
             self.driver_command or "krunkit",
             f"--memory={self.memory}",
@@ -209,7 +210,7 @@ class VM:
             f"--device=virtio-blk,path={self.disk['image']}",
             f"--device=virtio-blk,path={self.cidata}",
             f"--device=virtio-serial,logFilePath={self.serial}",
-            "--krun-log-level=3",
+            f"--krun-log-level={log_level}",
             "--device=virtio-rng",
         ]
 


### PR DESCRIPTION
Without this enabling debug level requires editing the krunkit command manually. With this change it is extremely easy to enable debug logs. Maybe too easy - krunkit debug log is extremely big, generating 6g during a 10 minutes stress test.