### PR TITLE
example: Default to 2 cpus

### DIFF
--- a/example
+++ b/example
@@ -111,8 +111,8 @@ def main():
         "--cpus",
         metavar="N",
         type=cpus,
-        default=1,
-        help="Number of vpus (1)",
+        default=2,
+        help="Number of vpus (2)",
     )
     p.add_argument(
         "--memory",


### PR DESCRIPTION
Without offloading we using more cpus does not improve results, but with offloading we see significant speedup with 2 cpus. 2 cpus are also closer to real vms, so a better default value.

krunkit offloading results with 1 and 2 cpus:

| Benchmark  | 1 CPU (Gbits/s) | 2 CPUs (Gbits/s) | Speedup  |
|------------|-----------------|------------------|----------|
| host to vm |            30.4 |             34.2 | **1.12** |
| vm to host |            48.5 |             47.8 |     0.98 |
| vm to vm   |            23.2 |             30.6 | **1.31** |