### PR TITLE
plots: Add vmnet-broker plot

### DIFF
--- a/plots/vmnet-broker.yaml
+++ b/plots/vmnet-broker.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Compare vmnet-helper to native vment
+---
+name: vmnet-helper vs vmnet-broker
+title: vmnet-helper
+networks: [vmnet-helper, vmnet-broker]
+drivers: [vfkit, krunkit, krunkit:offload, native]
+vms: [2]
+operation-modes: [shared]
+tests: [host-to-vm, vm-to-host, vm-to-vm]


### PR DESCRIPTION
Compare vmnet-helper drivers to native vmnet support in the virtualization framework, using vmnet-broker test-swift vm.

The benchmarks need to run manually and stored in:

    out/
        bench/
            vmnet-broker/
                shared-native-2/
                    vm-to-host.json
                    host-to-vm.json
                    vm-to-vm.json

The new plot is created using:

    ./bench plot plots/vmnet-broker.yaml