### PR TITLE
Tune endpoint memory usage

### DIFF
--- a/helper.c
+++ b/helper.c
@@ -30,12 +30,10 @@
 #include "version.h"
 #include "vmnet-broker.h"
 
-// vmnet_read() can return up to 256 packets. There is no constant in vmnet for
-// this value. https://developer.apple.com/documentation/vmnet?language=objc
-// sendmsg_x() and recvmsg_x() do not document any value but testing show that
-// we can read or write 64 packets in one call.  Tesiting with iperf3 shows
-// that there is no reason to use more than 64.
-#define MAX_PACKET_COUNT 64
+// vmnet_read() can return up to 200 packets and 256 KiB. There is no constant
+// in vmnet for this value. https://developer.apple.com/documentation/vmnet?language=objc.
+// Tesiting with iperf3 shows that there is no reason to use more than 128.
+#define MAX_PACKET_COUNT 128
 
 #define MICROSECOND 1000
 


### PR DESCRIPTION
- Use fewer buffers (16) when using offloading (65550 bytes per packet).
- Use more buffers (128) when not using offloading (1514 bytes per packet).

Testing shows that when reading from vment we can get 128 packets in one call. When reading from the VM we never get more than 64 packets. Maybe we can use less buffers for the vm endpoint, but it does not look interesting.