### PR TITLE
Rename vmnet-client to vmnet-run

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         driver: [vfkit, qemu]
-        connection: [fd, socket, client]
+        connection: [fd, socket, runner]
         exclude:
           - driver: qemu
             connection: socket

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ for arch in arm64 x86_64; do
     meson compile -C "$build_dir/$arch"
 done
 
-for prog in vmnet-helper vmnet-client; do
+for prog in vmnet-helper vmnet-run; do
     lipo -create "$build_dir/x86_64/$prog" "$build_dir/arm64/$prog" -output "$build_dir/$prog"
 done
 
@@ -28,7 +28,7 @@ rm -rf "$root_dir"
 bin_dir="$root_dir$prefix/bin"
 
 install -v -d -m 0755 "$bin_dir"
-for prog in vmnet-helper vmnet-client; do
+for prog in vmnet-helper vmnet-run; do
     install -v -m 0755 $build_dir/$prog $bin_dir
 done
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,9 +77,9 @@ process and the vmnet network.
 
 The program that starts vmnet-helper and the VM connects them using a pair of
 unix datagram sockets. Some programs like [minikube] do this internally. For
-programs that don't, **vmnet-client** is a small supervisor that starts
+programs that don't, **vmnet-run** is a small supervisor that starts
 vmnet-helper and the VM, connects them using a socketpair, and terminates both
-when the client exits.
+when it exits.
 
 ```mermaid
 flowchart TB
@@ -94,7 +94,7 @@ flowchart TB
     fd1 <--> fd2
   end
 
-  subgraph vmnet-client
+  subgraph vmnet-run
     subgraph vm2["QEMU vm 192.168.105.3"]
       fd3["fd"]
     end
@@ -119,7 +119,7 @@ flowchart TB
 ```
 
 - **minikube**: Starts vfkit and vmnet-helper internally, connecting them via a socketpair.
-- **vmnet-client**: A small supervisor that starts QEMU and vmnet-helper, connecting them via a socketpair.
+- **vmnet-run**: A small supervisor that starts QEMU and vmnet-helper, connecting them via a socketpair.
 - **vmnet1, vmnet2**: vmnet interfaces (one per helper), attached to the bridge.
 - **bridge100**: Host bridge for the subnet; typically has the subnet’s gateway IP (e.g. 192.168.105.1).
 
@@ -164,7 +164,7 @@ flowchart TB
   subgraph vm1["vfkit vm 192.168.64.2"]
   end
 
-  subgraph vmnet-client1
+  subgraph vmnet-run1
     subgraph vm2["libkrun vm 192.168.64.3"]
       fd1["fd"]
     end

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -105,16 +105,19 @@ INFO  [main] waiting for termination
 > If you want to recover from failures, restart the helper to create a
 > new unix socket and reconnect.
 
-## Starting the helper with vmnet-client
+## Starting the helper with vmnet-run
+
+> [!NOTE]
+> *vmnet-run* was called *vmnet-client* in versions before v0.11.0.
 
 To use the helper from a shell script without using a bound unix socket, you
-can use *vmnet-client*. The client creates a socketpair, and starts the helper
+can use *vmnet-run*. It creates a socketpair, and starts the helper
 with one socket, and the command provided by the user with the other socket.
 
 Example run with *vfkit*:
 
 ```console
-/opt/vmnet-helper/bin/vmnet-client -- \
+/opt/vmnet-helper/bin/vmnet-run -- \
     vfkit \
     --bootloader=efi,variable-store=efi-variable-store,create \
     "--device=virtio-blk,path=disk.img" \
@@ -122,9 +125,9 @@ Example run with *vfkit*:
 ```
 
 > [!IMPORTANT]
-> The command run by *vmnet-client* must use file descriptor 4.
+> The command run by *vmnet-run* must use file descriptor 4.
 
-See the [examples](/examples/) for more examples of using *vmnet-client*.
+See the [examples](/examples/) for more examples of using *vmnet-run*.
 
 > [!TIP]
 > On macOS 26 and later, use the `--unprivileged` option to run the
@@ -214,10 +217,10 @@ Example using vmnet-helper directly:
        --network shared
 ```
 
-Example using vmnet-client:
+Example using vmnet-run:
 
 ```console
-/opt/vmnet-helper/bin/vmnet-client --network shared --unprivileged -- \
+/opt/vmnet-helper/bin/vmnet-run --network shared --unprivileged -- \
     vfkit \
     --bootloader=efi,variable-store=efi-variable-store,create \
     "--device=virtio-blk,path=disk.img" \

--- a/example
+++ b/example
@@ -31,7 +31,7 @@ def main():
     p.add_argument("vm_name", help="VM name")
     p.add_argument(
         "--connection",
-        choices=["fd", "socket", "client"],
+        choices=["fd", "socket", "runner"],
         default="fd",
         help="How to connect the helper and vm (fd)",
     )
@@ -173,11 +173,11 @@ def main():
         if args.start_address or args.end_address or args.subnet_mask:
             p.error("--operation-mode required when using address options")
 
-    if args.connection == "client":
+    if args.connection == "runner":
         if args.driver == "krunkit":
-            p.error("--driver=krunkit not supported with --connection=client")
+            p.error("--driver=krunkit not supported with --connection=runner")
         if args.enable_offloading:
-            p.error("--enable-offloading not supported with --connection=client")
+            p.error("--enable-offloading not supported with --connection=runner")
 
     signal.signal(signal.SIGTERM, terminate)
     signal.signal(signal.SIGINT, terminate)
@@ -186,8 +186,8 @@ def main():
         run_with_fd(args)
     elif args.connection == "socket":
         run_with_socket(args)
-    elif args.connection == "client":
-        run_with_client(args)
+    elif args.connection == "runner":
+        run_with_runner(args)
 
 
 class SecondsFormatter(logging.Formatter):
@@ -256,11 +256,11 @@ def run_with_socket(args):
         helper.stop()
 
 
-def run_with_client(args):
+def run_with_runner(args):
     """
-    Use vmnet-client to run a vm with fd.
+    Use vmnet-run to run a vm with fd.
     """
-    vm = vmnet.VM(args, vmnet.mac_address_from(args.vm_name), fd=4, client=vmnet.CLIENT)
+    vm = vmnet.VM(args, vmnet.mac_address_from(args.vm_name), fd=4, runner=vmnet.RUNNER)
     vm.start()
     try:
         vm.wait_for_ip_address(timeout=args.timeout)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # Examples
 
 This directory contains examples for using *vmnet-helper* and
-*vmnet-client*:
+*vmnet-run*:
 
 - [qemu.sh](#qemu.sh)
 - [vfkit.sh](#vfkit.sh)
@@ -12,7 +12,7 @@ This directory contains examples for using *vmnet-helper* and
 ## qemu.sh
 
 This example shows how to start a *QEMU* virtual machine connected to a vmnet
-network interface using the vmnet-client wrapper.
+network interface using the vmnet-run wrapper.
 
 To start the example virtual machine run:
 
@@ -26,7 +26,7 @@ iso image, and starts a *QEMU* virtual machine with both images.
 ## vfkit.sh
 
 This example shows how to start a *vfkit* virtual machine connected to a vmnet
-network interface using the vmnet-client wrapper.
+network interface using the vmnet-run wrapper.
 
 To start the example virtual machine run:
 

--- a/examples/qemu.sh
+++ b/examples/qemu.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Example for using vmnet-client with QEMU.
+# Example for using vmnet-run with QEMU.
 
 MAC_ADDRESS="92:c9:52:b7:6c:08"
 DISK_IMAGE="disk.img"
@@ -18,7 +18,7 @@ if [ ! -f "$CIDATA_ISO" ]; then
 fi
 
 # Start qemu and vmnet-helper connected via unix datagram sockets.
-/opt/vmnet-helper/bin/vmnet-client -- \
+/opt/vmnet-helper/bin/vmnet-run -- \
     qemu-system-aarch64 \
     -m 1024 \
     -cpu host \

--- a/examples/vfkit.sh
+++ b/examples/vfkit.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Example for using vmnet-client with vfkit.
+# Example for using vmnet-run with vfkit.
 
 MAC_ADDRESS="92:c9:52:b7:6c:08"
 DISK_IMAGE="disk.img"
@@ -18,7 +18,7 @@ if [ ! -f "$CIDATA_ISO" ]; then
 fi
 
 # Start vfkit and vmnet-helper connected via unix datagram sockets.
-/opt/vmnet-helper/bin/vmnet-client -- \
+/opt/vmnet-helper/bin/vmnet-run -- \
     vfkit \
     --memory=1024 \
     --cpus=1 \

--- a/meson.build
+++ b/meson.build
@@ -45,9 +45,9 @@ vmnet_helper = executable(
   ],
 )
 
-vmnet_client = executable(
-  'vmnet-client',
-  'client.c',
+vmnet_run = executable(
+  'vmnet-run',
+  'run.c',
   install: true,
   dependencies: [
     version_h_dep,

--- a/run.c
+++ b/run.c
@@ -70,7 +70,7 @@ enum {
 static const char *short_options = ":vh";
 
 static struct option long_options[] = {
-    // vmnet-helper options that can be specified via vmnet-client.
+    // vmnet-helper options that can be specified via vmnet-run.
     {"interface-id",            required_argument,  0,  OPT_INTERFACE_ID},
     {"operation-mode",          required_argument,  0,  OPT_OPERATION_MODE},
     {"shared-interface",        required_argument,  0,  OPT_SHARED_INTERFACE},
@@ -93,12 +93,12 @@ static void usage(int code)
 "\n"
 "Run command with vmnet-helper\n"
 "\n"
-"    vmnet-client [--interface-id UUID] [--operation-mode shared|bridged|host]\n"
-"                 [--start-address ADDR] [--end-address ADDR]\n"
-"                 [--subnet-mask MASK] [--shared-interface NAME]\n"
-"                 [--enable-isolation] [--network NAME] [--unprivileged]\n"
-"                 [-v|--verbose] [--version] [-h|--help]\n"
-"                 -- command ...\n"
+"    vmnet-run [--interface-id UUID] [--operation-mode shared|bridged|host]\n"
+"              [--start-address ADDR] [--end-address ADDR]\n"
+"              [--subnet-mask MASK] [--shared-interface NAME]\n"
+"              [--enable-isolation] [--network NAME] [--unprivileged]\n"
+"              [-v|--verbose] [--version] [-h|--help]\n"
+"              -- command ...\n"
 "\n"
 "Modes:\n"
 "    By default, vmnet-helper creates a new network using the specified options.\n"

--- a/vmnet/__init__.py
+++ b/vmnet/__init__.py
@@ -3,7 +3,7 @@
 
 from .disks import IMAGES
 from .helper import (
-    CLIENT,
+    RUNNER,
     Helper,
     NET_IPV4_MASK,
     NET_IPV4_SUBNET,

--- a/vmnet/helper.py
+++ b/vmnet/helper.py
@@ -15,7 +15,7 @@ from . import store
 
 PREFIX = "/opt/vmnet-helper"
 HELPER = os.path.join(PREFIX, "bin/vmnet-helper")
-CLIENT = os.path.join(PREFIX, "bin/vmnet-client")
+RUNNER = os.path.join(PREFIX, "bin/vmnet-run")
 OPERATION_MODES = ["shared", "bridged", "host"]
 
 # Apple recommends sizing the receive buffer at 4 times the size of the send

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -28,13 +28,13 @@ QEMU_CONFIG = {
 
 
 class VM:
-    def __init__(self, args, mac_address, fd=None, socket=None, client=None):
+    def __init__(self, args, mac_address, fd=None, socket=None, runner=None):
         # Configuration
         self.args = args
         self.mac_address = mac_address
         self.fd = fd
         self.socket = socket
-        self.client = client
+        self.runner = runner
         self.vm_name = args.vm_name
         self.verbose = args.verbose
         self.driver = args.driver
@@ -83,8 +83,8 @@ class VM:
         stdout = None
         logfile = store.vm_path(self.vm_name, f"{self.driver}.log")
         with open(logfile, "w") as log:
-            if self.client:
-                cmd = self.client_command(cmd)
+            if self.runner:
+                cmd = self.runner_command(cmd)
                 stdout = log
             elif self.fd is not None:
                 pass_fds = [self.fd]
@@ -292,8 +292,8 @@ class VM:
 
         return cmd
 
-    def client_command(self, vm_command):
-        cmd = [self.client]
+    def runner_command(self, vm_command):
+        cmd = [self.runner]
         if self.args.network_name:
             cmd.append(f"--network={self.args.network_name}")
         elif self.args.operation_mode:


### PR DESCRIPTION
The name "vmnet-client" was inherited from socket_vmnet but was never a good fit. The program is a small supervisor that runs a command connected to the vmnet network, similar to how systemd-run runs a command as a transient service.

In the code, the runner is referred to as "runner" (e.g. RUNNER, self.runner, runner_command) to be consistent with "helper", while the program name "vmnet-run" is clearer when seen in a full command line.

Example:

    % ./build/vmnet-run --network shared --unprivileged -- sleep 1

Fixes #168