### PR TITLE
Remove krunkit restriction with --connection=runner

### DIFF
--- a/example
+++ b/example
@@ -174,8 +174,6 @@ def main():
             p.error("--operation-mode required when using address options")
 
     if args.connection == "runner":
-        if args.driver == "krunkit":
-            p.error("--driver=krunkit not supported with --connection=runner")
         if args.enable_offloading:
             p.error("--enable-offloading not supported with --connection=runner")
 


### PR DESCRIPTION
The restriction was added because krunkit originally only supported --device virtio-net,unixSocketPath=, but current versions support type=unixgram,fd= and type=unixgram,path=, so the runner works fine with krunkit now.

Fixes #194