### PR TITLE
Update actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Checkout source (pull request only)
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get latest release info
         id: release

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -41,7 +41,7 @@ jobs:
         if: matrix.driver == 'vfkit'
         run: brew install vfkit
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build vmnet-helper
         run: ./build.sh build
       - name: Install vmnet-helper

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "Commit SHA: ${{ github.sha }}"
 
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
           uname -a
           sw_vers
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Ensure tag
         # Archiving requires a tag, but we checkout only the last commit.
         run: git describe --tags 2>/dev/null || git tag devel
@@ -70,7 +70,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Ensure tag
         run: git describe --tags 2>/dev/null || git tag devel
       - name: Install requirements
@@ -87,7 +87,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check formatting
         run: |
           python3 -m venv .venv
@@ -101,7 +101,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install requirements
         run: brew install meson codespell
       - name: Setup


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to run with Node.js 24 starting June 2nd, 2026. Update to the latest version (v6.0.2) which uses the Node.js 24 runtime.

Fixes #196