### PR TITLE
Add offloading options to vmnet-run

### DIFF
--- a/example
+++ b/example
@@ -173,10 +173,6 @@ def main():
         if args.start_address or args.end_address or args.subnet_mask:
             p.error("--operation-mode required when using address options")
 
-    if args.connection == "runner":
-        if args.enable_offloading:
-            p.error("--enable-offloading not supported with --connection=runner")
-
     signal.signal(signal.SIGTERM, terminate)
     signal.signal(signal.SIGINT, terminate)
 

--- a/run.c
+++ b/run.c
@@ -27,6 +27,8 @@ struct client_options {
     char *subnet_mask;
     char *shared_interface;
     char *network_name;
+    bool enable_tso;
+    bool enable_checksum_offload;
     bool enable_isolation;
 
     // Client options.
@@ -61,6 +63,8 @@ enum {
     OPT_START_ADDRESS,
     OPT_END_ADDRESS,
     OPT_SUBNET_MASK,
+    OPT_ENABLE_TSO,
+    OPT_ENABLE_CHECKSUM_OFFLOAD,
     OPT_ENABLE_ISOLATION,
     OPT_NETWORK,
     OPT_UNPRIVILEGED,
@@ -77,6 +81,8 @@ static struct option long_options[] = {
     {"start-address",           required_argument,  0,  OPT_START_ADDRESS},
     {"end-address",             required_argument,  0,  OPT_END_ADDRESS},
     {"subnet-mask",             required_argument,  0,  OPT_SUBNET_MASK},
+    {"enable-tso",              no_argument,        0,  OPT_ENABLE_TSO},
+    {"enable-checksum-offload", no_argument,        0,  OPT_ENABLE_CHECKSUM_OFFLOAD},
     {"enable-isolation",        no_argument,        0,  OPT_ENABLE_ISOLATION},
     {"network",                 required_argument,  0,  OPT_NETWORK},
     {"verbose",                 no_argument,        0,  'v'},
@@ -96,6 +102,7 @@ static void usage(int code)
 "    vmnet-run [--interface-id UUID] [--operation-mode shared|bridged|host]\n"
 "              [--start-address ADDR] [--end-address ADDR]\n"
 "              [--subnet-mask MASK] [--shared-interface NAME]\n"
+"              [--enable-tso] [--enable-checksum-offload]\n"
 "              [--enable-isolation] [--network NAME] [--unprivileged]\n"
 "              [-v|--verbose] [--version] [-h|--help]\n"
 "              -- command ...\n"
@@ -167,6 +174,14 @@ static void build_helper_argv(void)
     if (options.shared_interface) {
         append_helper_arg("--shared-interface");
         append_helper_arg(options.shared_interface);
+    }
+
+    if (options.enable_tso) {
+        append_helper_arg("--enable-tso");
+    }
+
+    if (options.enable_checksum_offload) {
+        append_helper_arg("--enable-checksum-offload");
     }
 
     if (options.enable_isolation) {
@@ -267,6 +282,12 @@ static void parse_options(int argc, char **argv)
         case OPT_SUBNET_MASK:
             validate_address(optarg, optname);
             options.subnet_mask = optarg;
+            break;
+        case OPT_ENABLE_TSO:
+            options.enable_tso = true;
+            break;
+        case OPT_ENABLE_CHECKSUM_OFFLOAD:
+            options.enable_checksum_offload = true;
             break;
         case OPT_ENABLE_ISOLATION:
             options.enable_isolation = true;

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -302,6 +302,8 @@ class VM:
                 cmd.append(f"--shared-interface={self.args.shared_interface}")
             elif self.args.operation_mode == "host" and self.args.enable_isolation:
                 cmd.append("--enable-isolation")
+        if self.enable_offloading:
+            cmd.extend(["--enable-tso", "--enable-checksum-offload"])
         if self.args.verbose:
             cmd.append("--verbose")
         if not self.args.privileged:


### PR DESCRIPTION
Add --enable-tso and --enable-checksum-offload options to vmnet-run, passed through to vmnet-helper. These options were previously only available when running vmnet-helper directly.

Since macOS 26.2 offloading works well and can significantly improve network performance. For example, with krunkit on M2 Max, host network throughput is 3-5x faster with offloading (~30 Gbits/s tx, ~47 Gbits/s rx vs ~7-10 Gbits/s without offloading).

Note that offloading does not work for all use cases. For example, accessing the VM from pod network does not work with offloading enabled (see #179).

Example run:

    % ./example server --driver krunkit --cpus 4 --connection=runner --enable-offloading
    [   0.052] INFO Creating cloud-init iso '/Users/nir/.vmnet-helper/vms/server/cidata.iso'
    [   0.059] INFO Starting 'krunkit' virtual machine 'server' with mac address '76:d4:d3:83:fc:14'
    [   6.079] INFO Virtual machine IP address: 192.168.105.2

    % iperf3 -c server-vmnet-helper.local
    ...
    [ ID] Interval           Transfer     Bitrate
    [  7]   0.00-10.01  sec  43.2 GBytes  37.1 Gbits/sec                  sender
    [  7]   0.00-10.01  sec  43.2 GBytes  37.1 Gbits/sec                  receiver

    % iperf3 -c server-vmnet-helper.local -R
    ...
    [ ID] Interval           Transfer     Bitrate         Retr
    [  7]   0.00-10.00  sec  52.7 GBytes  45.3 Gbits/sec    0            sender
    [  7]   0.00-10.00  sec  52.7 GBytes  45.3 Gbits/sec                  receiver

Fixes #177