### PR TITLE
ci: Improve mDNS debugging and upload VM logs

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -131,3 +131,24 @@ jobs:
           done
           echo "timeout terminating example" >&2
           exit 1
+      - name: Collect logs
+        if: always()
+        run: |
+          vm="$HOME/.vmnet-helper/vms/test"
+          find "$vm" -maxdepth 1 -type f \
+              -not -name "*.img" \
+              -not -name "*.iso" \
+              -not -name "kernel" \
+              -not -name "initrd" \
+              > artifacts.txt
+          test -f /var/db/dhcpd_leases && echo /var/db/dhcpd_leases >> artifacts.txt
+          sudo tar --create --gzip \
+              --file vmnet-helper-integration-${{ matrix.driver }}-${{ matrix.connection }}.tar.gz \
+              --files-from artifacts.txt
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: vmnet-helper-integration-${{ matrix.driver }}-${{ matrix.connection }}
+          path: vmnet-helper-integration-${{ matrix.driver }}-${{ matrix.connection }}.tar.gz
+          compression-level: 0


### PR DESCRIPTION
## Summary

- Flush mDNS cache before starting test VMs to rule out negative
  caching as a cause of slow mDNS resolution on CI
- Show file timestamps in tree output and DHCP leases modification
  time for correlating DHCP lease with mDNS resolution
- Use sudo for reading VM files owned by root
- Upload VM logs (serial.log, vmnet-helper.log, etc.) as build
  artifacts for full inspection without truncation

## Context

mDNS resolution on CI runners sometimes takes 2-4 minutes or times
out entirely, even though the VM is booted and reachable. Locally,
mDNS resolves in about 5 seconds. The flush did not fix the issue,
so the delay is likely caused by slow VM boot on shared Intel
runners rather than mDNS caching. The uploaded log artifacts will
help diagnose future occurrences by showing the full serial.log
with kernel boot timestamps.

Related-to: #200