### PR TITLE
run: Resolve helper path from argv[0]

### DIFF
--- a/common.h
+++ b/common.h
@@ -1,10 +1,8 @@
 // SPDX-FileCopyrightText: The vmnet-helper authors
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef CONFIG_H
-#define CONFIG_H
-
-#define PREFIX "@PREFIX@"
+#ifndef COMMON_H
+#define COMMON_H
 
 // Apple recommends sizing the receive buffer at 4 times the size of the send
 // buffer, and other projects typically use a 1 MiB send buffer and a 4 MiB
@@ -20,4 +18,4 @@
 // queue more packets when using the vmnet_enable_tso option.
 #define RECV_BUFFER_SIZE (4 * 1024 * 1024)
 
-#endif // CONFIG_H
+#endif // COMMON_H

--- a/helper.c
+++ b/helper.c
@@ -23,7 +23,7 @@
 #include <uuid/uuid.h>
 #include <vmnet/vmnet.h>
 
-#include "config.h"
+#include "common.h"
 #include "log.h"
 #include "options.h"
 #include "socket_x.h"

--- a/meson.build
+++ b/meson.build
@@ -13,10 +13,6 @@ project(
   ],
 )
 
-config = configuration_data()
-config.set('PREFIX', get_option('prefix'))
-configure_file(input: 'config.h.in', output: 'config.h', configuration: config)
-
 gen_version = find_program('gen-version')
 version_h = custom_target(
   'version.h',

--- a/run.c
+++ b/run.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <getopt.h>
+#include <libgen.h>
 #include <limits.h>
 #include <signal.h>
 #include <stdio.h>
@@ -14,7 +15,7 @@
 #include <unistd.h>
 #include <uuid/uuid.h>
 
-#include "config.h"
+#include "common.h"
 #include "log.h"
 #include "version.h"
 
@@ -44,6 +45,9 @@ bool verbose = false;
 
 // Client options parsed from the command line.
 static struct client_options options;
+
+// Path to vmnet-helper, resolved from argv[0].
+static char helper_path[PATH_MAX];
 
 // vmnet-helper arguments. Built by build_helper_argv().
 static char *helper_argv[32];
@@ -131,6 +135,13 @@ static void append_helper_arg(char *arg)
     helper_next++;
 }
 
+// Resolve path to vmnet-helper relative to our own executable. Both binaries
+// are always installed in the same directory.
+static void resolve_helper_path(char *runner_path)
+{
+    snprintf(helper_path, sizeof(helper_path), "%s/vmnet-helper", dirname(runner_path));
+}
+
 static void build_helper_argv(void)
 {
     if (!options.unprivileged) {
@@ -143,7 +154,7 @@ static void build_helper_argv(void)
         append_helper_arg("--close-from=4");
     }
 
-    append_helper_arg(PREFIX "/bin/vmnet-helper");
+    append_helper_arg(helper_path);
     append_helper_arg("--fd=3");
 
     if (options.interface_id) {
@@ -557,6 +568,7 @@ static void setup_signals(void)
 int main(int argc, char **argv)
 {
     parse_options(argc, argv);
+    resolve_helper_path(argv[0]);
     build_helper_argv();
 
     setup_signals();


### PR DESCRIPTION
vmnet-run used a compile-time PREFIX to locate vmnet-helper at PREFIX/bin/vmnet-helper. This breaks Homebrew installs where the prefix differs from /opt/vmnet-helper.

Since both binaries are always installed in the same directory, resolve the helper path relative to the runner using dirname().

PREFIX has no remaining users, so remove config.h.in and the meson configure_file step. Rename to common.h as a plain shared header.

Example run:

    % ./build/vmnet-run --network shared --unprivileged -- sleep 1
    INFO  [main] running ./build/vmnet-helper v0.10.0-8-g86e9554 on macOS 26.4.0

This also helps testing on macOS 26. We don't need to install vmnet-helper or vmnet-run to test them. On older macOS we need to install to use the default sudoers rule, hard-coded to /opt/vmnet-helper.

Fixes #203