### PR TITLE
docs: Add macOS 15 note to launchd guide

### DIFF
--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -155,6 +155,10 @@ from vmnet across restarts:
 INTERFACE_ID=$(uuidgen)
 ```
 
+> [!NOTE]
+> On macOS 15, replace the vmnet-run path in the plist with
+> `/opt/vmnet-helper/bin/vmnet-run`.
+
 Create the plist:
 
 ```console


### PR DESCRIPTION
The guide uses Homebrew paths which are only available on macOS 26. Add a note with the replacement path for macOS 15 users.