### PR TITLE
Support --start-address --end-address --subnet-mask in host mode

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -145,6 +145,11 @@ Options:
   isolation ensures that network communication between multiple vmnet
   interface instances is not possible.
 
+- **--start-address**, **--end-address**, **--subnet-mask**: Optional DHCP
+  pool for the host network. All three must be given together, or all three
+  omitted. When omitted, vmnet selects the next available network. See
+  [Network selection and conflicts](#network-selection-and-conflicts).
+
 ### --operation-mode=shared
 
 Allows traffic originating from the vmnet interface to reach the
@@ -170,6 +175,10 @@ Options:
   also specify **--start-address** and **--end-address** (default
   "255.255.255.0").
 
+See [Network selection and conflicts](#network-selection-and-conflicts) for
+how the default shared subnet relates to host mode and other vmnet users on
+the host.
+
 ### --operation-mode=bridged
 
 Bridges the vmnet interface with a physical network interface. When
@@ -187,6 +196,43 @@ using the **--list-shared-interfaces** option.
 en10
 en0
 ```
+
+## Network selection and conflicts
+
+How vmnet-helper picks an IPv4 subnet depends on the operation mode and on
+what other vmnet users are already running on the machine.
+
+### Shared mode
+
+When `--start-address`, `--end-address`, and `--subnet-mask` are omitted,
+vmnet-helper currently supplies fixed defaults (192.168.105.1,
+192.168.105.254, and 255.255.255.0). That matches the historical default
+shared subnet, but it does **not** match leaving options unset when using
+vmnet directly (vmnet would choose a subnet). The plan is to stop
+injecting these defaults and let vmnet select the network instead.
+
+### Host mode
+
+When all three address options are omitted, vmnet selects the next
+available network (for example 192.168.128.0/24 when that range is still
+free). If another program has already reserved the default host subnet,
+vmnet allocates a different free range, similar to [vmnet-broker] shared
+and host networks when no explicit subnet is configured.
+
+### Conflicts between shared and host networks and other programs
+
+The same IPv4 subnet cannot be used for both a shared-mode vmnet network
+and a host-mode vmnet network: whichever process creates the network
+first owns that range. Other software using vmnet (for example another
+vmnet-helper, [socket_vmnet], or [vmnet-broker]) may already have created
+`a.b.c.d/24`. Starting a second program with overlapping DHCP options for
+a different mode can hang or fail.
+
+For example, if socket_vmnet runs as a launch daemon and creates
+192.168.105.0/24 at boot, running vmnet-helper in host mode with explicit
+options for that same subnet conflicts with it. Omitting the address
+options for host mode lets vmnet pick a different subnet (often
+192.168.128.0/24) when it is still available.
 
 ## Network mode (macOS 26)
 
@@ -269,4 +315,5 @@ The vmnet helper logs to stderr. You can read the logs and integrate
 them in your application logs or redirect them to a file.
 
 [native-vmnet]: /docs/architecture.md#native-vmnet-on-macos-26
+[socket_vmnet]: https://github.com/lima-vm/socket_vmnet
 [vmnet-broker]: https://github.com/nirs/vmnet-broker

--- a/helper.c
+++ b/helper.c
@@ -287,15 +287,15 @@ static void start_interface_with_options(void)
     switch (options.operation_mode) {
     case VMNET_SHARED_MODE:
         DEBUGF("[main] starting interface mode '%s' interface-id '%s' "
-               "enable-tso %s enable-checksum-offload %s "
-               "start-address '%s' end-address '%s' subnet-mask '%s'",
+               "start-address '%s' end-address '%s' subnet-mask '%s' "
+               "enable-tso %s enable-checksum-offload %s",
                mode_name(options.operation_mode),
                interface_id,
-               options.enable_tso ? "true" : "false",
-               options.enable_checksum_offload ? "true" : "false",
                options.start_address,
                options.end_address,
-               options.subnet_mask);
+               options.subnet_mask,
+               options.enable_tso ? "true" : "false",
+               options.enable_checksum_offload ? "true" : "false");
         break;
     case VMNET_BRIDGED_MODE:
         DEBUGF("[main] starting interface mode '%s' interface-id '%s' "

--- a/helper.c
+++ b/helper.c
@@ -309,10 +309,14 @@ static void start_interface_with_options(void)
         break;
     case VMNET_HOST_MODE:
         DEBUGF("[main] starting interface mode '%s' interface-id '%s' "
+               "start-address '%s' end-address '%s' subnet-mask '%s' "
                "enable-tso %s enable-checksum-offload %s "
                "enable-isolation %s",
                mode_name(options.operation_mode),
                interface_id,
+               options.start_address,
+               options.end_address,
+               options.subnet_mask,
                options.enable_tso ? "true" : "false",
                options.enable_checksum_offload ? "true" : "false",
                options.enable_isolation ? "true" : "false");
@@ -331,11 +335,18 @@ static void start_interface_with_options(void)
         xpc_dictionary_set_string(desc, vmnet_shared_interface_name_key, options.shared_interface);
         break;
     case VMNET_SHARED_MODE:
+        // In shared mode all network options have defaults.
         xpc_dictionary_set_string(desc, vmnet_start_address_key, options.start_address);
         xpc_dictionary_set_string(desc, vmnet_end_address_key, options.end_address);
         xpc_dictionary_set_string(desc, vmnet_subnet_mask_key, options.subnet_mask);
         break;
     case VMNET_HOST_MODE:
+        // In host mode all network options are set or NULL.
+        if (options.start_address != NULL) {
+            xpc_dictionary_set_string(desc, vmnet_start_address_key, options.start_address);
+            xpc_dictionary_set_string(desc, vmnet_end_address_key, options.end_address);
+            xpc_dictionary_set_string(desc, vmnet_subnet_mask_key, options.subnet_mask);
+        }
         xpc_dictionary_set_bool(desc, vmnet_enable_isolation_key, options.enable_isolation);
         break;
     default:

--- a/options.c
+++ b/options.c
@@ -178,6 +178,18 @@ static void list_shared_interfaces(void)
     exit(0);
 }
 
+// All three address options must be given together or all omitted.
+// See docs/integration.md.
+static void validate_network_options(struct options *opts)
+{
+    int options_set = (opts->start_address != NULL) + (opts->end_address != NULL) +
+                      (opts->subnet_mask != NULL);
+    if (options_set != 0 && options_set != 3) {
+        ERROR("--start-address, --end-address, and --subnet-mask must be given together, or all omitted");
+        exit(EXIT_FAILURE);
+    }
+}
+
 void parse_options(struct options *opts, int argc, char **argv)
 {
     const char *optname;
@@ -282,8 +294,9 @@ void parse_options(struct options *opts, int argc, char **argv)
 
         switch (opts->operation_mode) {
         case VMNET_SHARED_MODE:
-            // Address defaults only apply to shared mode.
-            // https://github.com/nirs/vmnet-helper/issues/121
+            // TODO:
+            // - Remove defaults: https://github.com/nirs/vmnet-helper/issues/123
+            // - Use validate_network_options()
             if (opts->start_address == NULL) {
                 opts->start_address = "192.168.105.1";
             }
@@ -300,6 +313,9 @@ void parse_options(struct options *opts, int argc, char **argv)
                 ERROR("Conflicting arguments: enable-isolation cannot be used with shared mode");
                 exit(EXIT_FAILURE);
             }
+            break;
+        case VMNET_HOST_MODE:
+            validate_network_options(opts);
             break;
         case VMNET_BRIDGED_MODE:
             if (opts->shared_interface == NULL) {

--- a/vmnet/helper.py
+++ b/vmnet/helper.py
@@ -149,6 +149,12 @@ class Helper:
             elif self.operation_mode == "bridged":
                 cmd.append(f"--shared-interface={self.shared_interface}")
             elif self.operation_mode == "host":
+                if self.start_address:
+                    cmd.append(f"--start-address={self.start_address}")
+                if self.end_address:
+                    cmd.append(f"--end-address={self.end_address}")
+                if self.subnet_mask:
+                    cmd.append(f"--subnet-mask={self.subnet_mask}")
                 if self.enable_isolation:
                     cmd.append("--enable-isolation")
             else:

--- a/vmnet/helper_test.py
+++ b/vmnet/helper_test.py
@@ -88,6 +88,10 @@ class TestStart:
         """
         with run_helper() as (h, sock):
             self.check_interface(h.interface)
+            # If network options are unset, the helper uses the default shared network.
+            assert h.interface[VMNET_START_ADDRESS] == "192.168.105.1"
+            assert h.interface[VMNET_END_ADDRESS] == "192.168.105.254"
+            assert h.interface[VMNET_SUBNET_MASK] == "255.255.255.0"
 
     def test_shared_mode(self):
         """
@@ -95,8 +99,12 @@ class TestStart:
         """
         with run_helper(operation_mode="shared") as (h, sock):
             self.check_interface(h.interface)
+            # If network options are unset, the helper uses the default shared network.
+            assert h.interface[VMNET_START_ADDRESS] == "192.168.105.1"
+            assert h.interface[VMNET_END_ADDRESS] == "192.168.105.254"
+            assert h.interface[VMNET_SUBNET_MASK] == "255.255.255.0"
 
-    def test_shared_mode_custom_subnet(self):
+    def test_shared_mode_specific_network(self):
         """
         Test starting helper with custom subnet configuration
         """
@@ -119,6 +127,7 @@ class TestStart:
             operation_mode="host",
         ) as (h, sock):
             self.check_interface(h.interface)
+            # If network options are unset, vmnet selects the next available network.
 
     def test_host_mode_isolated(self):
         """

--- a/vmnet/helper_test.py
+++ b/vmnet/helper_test.py
@@ -129,6 +129,21 @@ class TestStart:
             self.check_interface(h.interface)
             # If network options are unset, vmnet selects the next available network.
 
+    def test_host_mode_specific_network(self):
+        """
+        Test starting helper with custom subnet configuration
+        """
+        with run_helper(
+            operation_mode="host",
+            start_address="192.168.200.1",
+            end_address="192.168.200.254",
+            subnet_mask="255.255.255.0",
+        ) as (h, sock):
+            self.check_interface(h.interface)
+            assert h.interface[VMNET_START_ADDRESS] == "192.168.200.1"
+            assert h.interface[VMNET_END_ADDRESS] == "192.168.200.254"
+            assert h.interface[VMNET_SUBNET_MASK] == "255.255.255.0"
+
     def test_host_mode_isolated(self):
         """
         Test starting helper in host mode with isolation


### PR DESCRIPTION
Previously host mode silently ignored network options, so vmnet always
selected the subnet. Now the three address options are accepted in host
mode. All three must be given together or all omitted; partial
combinations are rejected.

See https://github.com/renode/renode/issues/895 for an example of
how the silent ignore confused another project.

Fixes #121