### PR TITLE
helper: Remove default network address for shared mode

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,12 +25,12 @@ between the VM and vmnet internally.
 ```mermaid
 flowchart TB
   subgraph qemu["QEMU"]
-    vm1["vm 192.168.105.2"]
+    vm1["vm 192.168.64.2"]
   end
 
   subgraph vmnet
     vmnet0
-    bridge["bridge100 192.168.105.1"]
+    bridge["bridge100 192.168.64.1"]
 
     vmnet0 <--> bridge
   end
@@ -84,7 +84,7 @@ when it exits.
 ```mermaid
 flowchart TB
   subgraph minikube
-    subgraph vm1["vfkit vm 192.168.105.2"]
+    subgraph vm1["vfkit vm 192.168.64.2"]
       fd1["fd"]
     end
     subgraph helper1["vmnet-helper 1"]
@@ -95,7 +95,7 @@ flowchart TB
   end
 
   subgraph vmnet-run
-    subgraph vm2["QEMU vm 192.168.105.3"]
+    subgraph vm2["QEMU vm 192.168.64.3"]
       fd3["fd"]
     end
     subgraph helper2["vmnet-helper 2"]
@@ -108,7 +108,7 @@ flowchart TB
   subgraph vmnet
     vmnet1
     vmnet2
-    bridge["bridge100 192.168.105.1"]
+    bridge["bridge100 192.168.64.1"]
 
     vmnet1 <--> bridge
     vmnet2 <--> bridge
@@ -121,7 +121,7 @@ flowchart TB
 - **minikube**: Starts vfkit and vmnet-helper internally, connecting them via a socketpair.
 - **vmnet-run**: A small supervisor that starts QEMU and vmnet-helper, connecting them via a socketpair.
 - **vmnet1, vmnet2**: vmnet interfaces (one per helper), attached to the bridge.
-- **bridge100**: Host bridge for the subnet; typically has the subnet’s gateway IP (e.g. 192.168.105.1).
+- **bridge100**: Host bridge for the subnet; typically has the subnet’s gateway IP (e.g. 192.168.64.1).
 
 Use the same subnet options for all VMs that should be on the same network.
 Use a stable `--interface-id` per VM so the MAC (and thus DHCP-assigned IP)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -31,7 +31,7 @@ Resizing image to 20g
 Creating disk '/Users/nir/.vmnet-helper/vms/vm/disk.img'
 Creating cloud-init iso '/Users/nir/.vmnet-helper/vms/vm/cidata.iso'
 Starting 'vfkit' virtual machine 'vm' with mac address 'a2:89:b2:31:d7:fb'
-Virtual machine IP address:  192.168.105.2
+Virtual machine IP address:  192.168.64.2
 ```
 
 To stop the virtual machine and the vmnet-helper press *Control+C*.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -33,8 +33,8 @@ Example run using jq to pretty print the response:
 {
   "vmnet_subnet_mask": "255.255.255.0",
   "vmnet_mtu": 1500,
-  "vmnet_end_address": "192.168.105.254",
-  "vmnet_start_address": "192.168.105.1",
+  "vmnet_end_address": "192.168.64.254",
+  "vmnet_start_address": "192.168.64.1",
   "vmnet_interface_id": "2835E074-9892-4A79-AFFB-7E41D2605678",
   "vmnet_max_packet_size": 1514,
   "vmnet_nat66_prefix": "fd9b:5a14:ba57:e3d3::",
@@ -145,10 +145,8 @@ Options:
   isolation ensures that network communication between multiple vmnet
   interface instances is not possible.
 
-- **--start-address**, **--end-address**, **--subnet-mask**: Optional DHCP
-  pool for the host network. All three must be given together, or all three
-  omitted. When omitted, vmnet selects the next available network. See
-  [Network selection and conflicts](#network-selection-and-conflicts).
+The network can be configured using the
+[network address options](#network-address-options).
 
 ### --operation-mode=shared
 
@@ -157,27 +155,8 @@ Internet through a network address translator (NAT). The vmnet interface
 can also communicate with the native host. By default, the vmnet
 interface is able to communicate with other shared mode interfaces.
 
-Options:
-
-- **--start-address**: The starting IPv4 address to use for the interface.
-  This address is used as the gateway address. The subsequent address up
-  to and including **--end-address** are placed in the DHCP pool.
-  All other addresses are available for static assignment.  The address
-  must be in the private IP range (RFC 1918).  Must be specified along
-  with **--end-address** and **--subnet-mask** (default "192.168.105.1").
-
-- **--end-address**: The DHCP IPv4 range end address (string) to use for
-  the interface.  The address must be in the private IP range (RFC
-  1918).  Must be specified with **--start-address** and
-  **--subnet-mask** (default "192.168.105.254").
-
-- **--subnet-mask**: The IPv4 subnet mask to use on the interface.  Must
-  also specify **--start-address** and **--end-address** (default
-  "255.255.255.0").
-
-See [Network selection and conflicts](#network-selection-and-conflicts) for
-how the default shared subnet relates to host mode and other vmnet users on
-the host.
+The network can be configured using the
+[network address options](#network-address-options).
 
 ### --operation-mode=bridged
 
@@ -197,49 +176,61 @@ en10
 en0
 ```
 
-## Network selection and conflicts
+## Network address options
 
-How vmnet-helper picks an IPv4 subnet depends on the operation mode and on
-what other vmnet users are already running on the machine.
+The IPv4 subnet can be specified using the address options, or omitted to
+let vmnet select the next available network automatically. These options
+apply to shared and host modes.
 
-### Shared mode
+> [!IMPORTANT]
+> All three options must be given together, or all three omitted.
 
-When `--start-address`, `--end-address`, and `--subnet-mask` are omitted,
-vmnet-helper currently supplies fixed defaults (192.168.105.1,
-192.168.105.254, and 255.255.255.0). That matches the historical default
-shared subnet, but it does **not** match leaving options unset when using
-vmnet directly (vmnet would choose a subnet). The plan is to stop
-injecting these defaults and let vmnet select the network instead.
+- **--start-address**: The starting IPv4 address to use for the interface.
+  This address is used as the gateway address. The subsequent addresses up
+  to and including **--end-address** are placed in the DHCP pool.
+  All other addresses are available for static assignment. The address
+  must be in the private IP range (RFC 1918).
 
-### Host mode
+- **--end-address**: The DHCP IPv4 range end address to use for the
+  interface. The address must be in the private IP range (RFC 1918).
 
-When all three address options are omitted, vmnet selects the next
-available network (for example 192.168.128.0/24 when that range is still
-free). If another program has already reserved the default host subnet,
-vmnet allocates a different free range, similar to [vmnet-broker] shared
-and host networks when no explicit subnet is configured.
+- **--subnet-mask**: The IPv4 subnet mask to use on the interface.
 
-### Conflicts between shared and host networks and other programs
+### Automatic network selection
 
-The same IPv4 subnet cannot be used for both a shared-mode vmnet network
-and a host-mode vmnet network: whichever process creates the network
-first owns that range. Other software using vmnet (for example another
-vmnet-helper, [socket_vmnet], or [vmnet-broker]) may already have created
-`a.b.c.d/24`. Starting a second program with overlapping DHCP options for
-a different mode can hang or fail.
+When all three address options are omitted, vmnet selects the next available
+network; the defaults are 192.168.64.0/24 for shared mode, and 192.168.128.0/24
+for host mode. If another program has already reserved the default network,
+vmnet allocates the next network (e.g. 192.168.65.0/24). This is similar to
+[vmnet-broker] shared and host networks when no explicit network is configured.
 
-For example, if socket_vmnet runs as a launch daemon and creates
-192.168.105.0/24 at boot, running vmnet-helper in host mode with explicit
-options for that same subnet conflicts with it. Omitting the address
-options for host mode lets vmnet pick a different subnet (often
-192.168.128.0/24) when it is still available.
+This is the most reliable way to start vmnet-helper since it avoids conflicts
+with other vmnet users. However, the network address is not known until
+vmnet-helper starts, so hard-coded addresses cannot be used in the VM
+configuration.
+
+> [!NOTE]
+> Before v0.12.0, shared mode used 192.168.105.0/24 when address options
+> were omitted. If you depend on a specific network, specify all three
+> address options explicitly.
+
+### Network conflicts
+
+The same IPv4 subnet cannot be used for both a shared-mode vmnet network and a
+host-mode vmnet network: whichever process creates the network first owns that
+range. If another program using vmnet has already created the same network
+in a different mode, vmnet-helper will fail.
+
+For example, if socket_vmnet runs as a launchd daemon and creates the network
+192.168.105.0/24 at boot, running vmnet-helper with explicit options for that
+same subnet conflicts with it. Omitting the address options lets vmnet select
+the next network (typically 192.168.65.0/24).
 
 ## Network mode (macOS 26)
 
-On macOS 26 and later, vmnet-helper can join a network managed by
-[vmnet-broker] instead of creating its own. This lets VMs using
-vmnet-helper share the same network as VMs using native vmnet via the
-Virtualization framework. See the
+On macOS 26 and later, vmnet-helper can join a network managed by [vmnet-broker]
+instead of creating its own. This lets VMs using vmnet-helper share the same
+network as VMs using native vmnet via the Virtualization framework. See the
 [architecture guide][native-vmnet] for details.
 
 - **--network NAME**: Join the named network managed by vmnet-broker

--- a/helper.c
+++ b/helper.c
@@ -335,13 +335,13 @@ static void start_interface_with_options(void)
         xpc_dictionary_set_string(desc, vmnet_shared_interface_name_key, options.shared_interface);
         break;
     case VMNET_SHARED_MODE:
-        // In shared mode all network options have defaults.
-        xpc_dictionary_set_string(desc, vmnet_start_address_key, options.start_address);
-        xpc_dictionary_set_string(desc, vmnet_end_address_key, options.end_address);
-        xpc_dictionary_set_string(desc, vmnet_subnet_mask_key, options.subnet_mask);
+        if (options.start_address != NULL) {
+            xpc_dictionary_set_string(desc, vmnet_start_address_key, options.start_address);
+            xpc_dictionary_set_string(desc, vmnet_end_address_key, options.end_address);
+            xpc_dictionary_set_string(desc, vmnet_subnet_mask_key, options.subnet_mask);
+        }
         break;
     case VMNET_HOST_MODE:
-        // In host mode all network options are set or NULL.
         if (options.start_address != NULL) {
             xpc_dictionary_set_string(desc, vmnet_start_address_key, options.start_address);
             xpc_dictionary_set_string(desc, vmnet_end_address_key, options.end_address);

--- a/options.c
+++ b/options.c
@@ -294,18 +294,7 @@ void parse_options(struct options *opts, int argc, char **argv)
 
         switch (opts->operation_mode) {
         case VMNET_SHARED_MODE:
-            // TODO:
-            // - Remove defaults: https://github.com/nirs/vmnet-helper/issues/123
-            // - Use validate_network_options()
-            if (opts->start_address == NULL) {
-                opts->start_address = "192.168.105.1";
-            }
-            if (opts->end_address == NULL) {
-                opts->end_address = "192.168.105.254";
-            }
-            if (opts->subnet_mask == NULL) {
-                opts->subnet_mask = "255.255.255.0";
-            }
+            validate_network_options(opts);
 
             // TODO: Validate that isolation doesn't work with shared mode.
             // https://github.com/nirs/vmnet-helper/issues/148

--- a/vmnet/helper_test.py
+++ b/vmnet/helper_test.py
@@ -88,10 +88,7 @@ class TestStart:
         """
         with run_helper() as (h, sock):
             self.check_interface(h.interface)
-            # If network options are unset, the helper uses the default shared network.
-            assert h.interface[VMNET_START_ADDRESS] == "192.168.105.1"
-            assert h.interface[VMNET_END_ADDRESS] == "192.168.105.254"
-            assert h.interface[VMNET_SUBNET_MASK] == "255.255.255.0"
+            # If network options are unset, vmnet selects the next available network.
 
     def test_shared_mode(self):
         """
@@ -99,10 +96,7 @@ class TestStart:
         """
         with run_helper(operation_mode="shared") as (h, sock):
             self.check_interface(h.interface)
-            # If network options are unset, the helper uses the default shared network.
-            assert h.interface[VMNET_START_ADDRESS] == "192.168.105.1"
-            assert h.interface[VMNET_END_ADDRESS] == "192.168.105.254"
-            assert h.interface[VMNET_SUBNET_MASK] == "255.255.255.0"
+            # If network options are unset, vmnet selects the next available network.
 
     def test_shared_mode_specific_network_16(self):
         """


### PR DESCRIPTION
Previously, shared mode used 192.168.105.0/24 when --start-address, --end-address, and --subnet-mask were omitted. Now shared mode behaves like host mode: vmnet selects the next available network automatically.

This fixes a bug where vmnet-helper would fail if 192.168.105.0/24 was already reserved by another program. Now vmnet-helper automatically selects the next available network instead of failing.

Another advantage is that the default shared network (192.168.64.0/24) matches the network used by --network shared on macOS 26, making future migration to vmnet-broker seamless.

Users who do not specify address options (e.g. minikube) will get whatever network vmnet assigns (typically 192.168.64.0/24 if available).  This is the most reliable way to run vmnet-helper since it avoids conflicts with other vmnet users. These users are not affected since they discover the network address from the vmnet interface at runtime.

Users who specify all three address options are not affected.

This is a breaking change for users who relied on the implicit 192.168.105.0/24 default without specifying address options. These users need to either specify the address options explicitly, or update their configuration to discover the network address at runtime.

The integration guide is reorganized to describe the address options in a dedicated section, shared by both shared and host modes, with guidance on automatic network selection and network conflicts.

The docs were updated to show the new default network (192.168.64.0/24) instead of the legacy network (192.168.105.0/24).

Fixes #123 