### PR TITLE
Allow --enable-isolation in shared mode and simplify options handling

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -139,12 +139,6 @@ framework, using the **--operation-mode** option.
 Allows the vmnet interface to communicate with other vmnet interfaces
 that are in host mode and also with the native host.
 
-Options:
-
-- **--enable-isolation**: Enable isolation for this interface. Interface
-  isolation ensures that network communication between multiple vmnet
-  interface instances is not possible.
-
 The network can be configured using the
 [network address options](#network-address-options).
 
@@ -175,6 +169,12 @@ using the **--list-shared-interfaces** option.
 en10
 en0
 ```
+
+## Interface isolation
+
+The **--enable-isolation** option ensures that network communication
+between multiple vmnet interface instances is not possible. This option
+is available for shared and host modes.
 
 ## Network address options
 

--- a/example
+++ b/example
@@ -156,15 +156,11 @@ def main():
         if args.subnet_mask:
             p.error("--network cannot be used with --subnet-mask")
 
-    if args.operation_mode:
-        if args.operation_mode == "bridged" and not args.shared_interface:
+    if args.operation_mode == "bridged":
+        if not args.shared_interface:
             p.error("--shared-interface required for --operation-mode=bridged")
-
-        if args.enable_isolation and args.operation_mode != "host":
-            p.error("--enable-isolation requires --operation-mode=host")
-    else:
-        if args.start_address or args.end_address or args.subnet_mask:
-            p.error("--operation-mode required when using address options")
+        if args.enable_isolation:
+            p.error("--enable-isolation not compatible with --operation-mode=bridged")
 
     signal.signal(signal.SIGTERM, terminate)
     signal.signal(signal.SIGINT, terminate)

--- a/helper.c
+++ b/helper.c
@@ -286,27 +286,6 @@ static void start_interface_with_options(void)
 
     switch (options.operation_mode) {
     case VMNET_SHARED_MODE:
-        DEBUGF("[main] starting interface mode '%s' interface-id '%s' "
-               "start-address '%s' end-address '%s' subnet-mask '%s' "
-               "enable-tso %s enable-checksum-offload %s",
-               mode_name(options.operation_mode),
-               interface_id,
-               options.start_address,
-               options.end_address,
-               options.subnet_mask,
-               options.enable_tso ? "true" : "false",
-               options.enable_checksum_offload ? "true" : "false");
-        break;
-    case VMNET_BRIDGED_MODE:
-        DEBUGF("[main] starting interface mode '%s' interface-id '%s' "
-               "enable-tso %s enable-checksum-offload %s "
-               "shared-interface '%s'",
-               mode_name(options.operation_mode),
-               interface_id,
-               options.enable_tso ? "true" : "false",
-               options.enable_checksum_offload ? "true" : "false",
-               options.shared_interface);
-        break;
     case VMNET_HOST_MODE:
         DEBUGF("[main] starting interface mode '%s' interface-id '%s' "
                "start-address '%s' end-address '%s' subnet-mask '%s' "
@@ -321,6 +300,16 @@ static void start_interface_with_options(void)
                options.enable_checksum_offload ? "true" : "false",
                options.enable_isolation ? "true" : "false");
         break;
+    case VMNET_BRIDGED_MODE:
+        DEBUGF("[main] starting interface mode '%s' interface-id '%s' "
+               "enable-tso %s enable-checksum-offload %s "
+               "shared-interface '%s'",
+               mode_name(options.operation_mode),
+               interface_id,
+               options.enable_tso ? "true" : "false",
+               options.enable_checksum_offload ? "true" : "false",
+               options.shared_interface);
+        break;
     }
 
     xpc_object_t desc = xpc_dictionary_create(NULL, NULL, 0);
@@ -331,16 +320,7 @@ static void start_interface_with_options(void)
     xpc_dictionary_set_uint64(desc, vmnet_operation_mode_key, options.operation_mode);
 
     switch (options.operation_mode) {
-    case VMNET_BRIDGED_MODE:
-        xpc_dictionary_set_string(desc, vmnet_shared_interface_name_key, options.shared_interface);
-        break;
     case VMNET_SHARED_MODE:
-        if (options.start_address != NULL) {
-            xpc_dictionary_set_string(desc, vmnet_start_address_key, options.start_address);
-            xpc_dictionary_set_string(desc, vmnet_end_address_key, options.end_address);
-            xpc_dictionary_set_string(desc, vmnet_subnet_mask_key, options.subnet_mask);
-        }
-        break;
     case VMNET_HOST_MODE:
         if (options.start_address != NULL) {
             xpc_dictionary_set_string(desc, vmnet_start_address_key, options.start_address);
@@ -348,6 +328,9 @@ static void start_interface_with_options(void)
             xpc_dictionary_set_string(desc, vmnet_subnet_mask_key, options.subnet_mask);
         }
         xpc_dictionary_set_bool(desc, vmnet_enable_isolation_key, options.enable_isolation);
+        break;
+    case VMNET_BRIDGED_MODE:
+        xpc_dictionary_set_string(desc, vmnet_shared_interface_name_key, options.shared_interface);
         break;
     default:
         assert(0);

--- a/options.c
+++ b/options.c
@@ -294,15 +294,6 @@ void parse_options(struct options *opts, int argc, char **argv)
 
         switch (opts->operation_mode) {
         case VMNET_SHARED_MODE:
-            validate_network_options(opts);
-
-            // TODO: Validate that isolation doesn't work with shared mode.
-            // https://github.com/nirs/vmnet-helper/issues/148
-            if (opts->enable_isolation) {
-                ERROR("Conflicting arguments: enable-isolation cannot be used with shared mode");
-                exit(EXIT_FAILURE);
-            }
-            break;
         case VMNET_HOST_MODE:
             validate_network_options(opts);
             break;
@@ -313,7 +304,6 @@ void parse_options(struct options *opts, int argc, char **argv)
             }
 
             // TODO: Validate that isolation doesn't work with bridged mode.
-            // https://github.com/nirs/vmnet-helper/issues/148
             if (opts->enable_isolation) {
                 ERROR("Conflicting arguments: enable-isolation cannot be used with bridged mode");
                 exit(EXIT_FAILURE);

--- a/run.c
+++ b/run.c
@@ -352,16 +352,15 @@ static void parse_options(int argc, char **argv)
             ERROR("[runner] conflicting arguments: --network cannot be used with --subnet-mask");
             exit(EXIT_FAILURE);
         }
-    } else {
-        if (is_bridged(options.operation_mode) && options.shared_interface == NULL) {
+    } else if (is_bridged(options.operation_mode)) {
+        if (options.shared_interface == NULL) {
             ERROR("[runner] missing argument: shared-interface is required for operation-mode=bridged");
             exit(EXIT_FAILURE);
         }
 
-        // TODO: Validate that isolation doesn't work with shared and bridged modes.
-        // https://github.com/nirs/vmnet-helper/issues/148
-        if (options.enable_isolation && !is_host(options.operation_mode)) {
-            ERROR("[runner] conflicting arguments: enable-isolation requires operation-mode=host");
+        // TODO: Validate that isolation doesn't work with bridged mode.
+        if (options.enable_isolation) {
+            ERROR("[runner] conflicting arguments: enable-isolation not compatible with operation-mode=bridged");
             exit(EXIT_FAILURE);
         }
     }

--- a/vmnet/helper.py
+++ b/vmnet/helper.py
@@ -136,29 +136,24 @@ class Helper:
 
         if self.network_name:
             cmd.append(f"--network={self.network_name}")
-        elif self.operation_mode:
+
+        if self.operation_mode:
             cmd.append(f"--operation-mode={self.operation_mode}")
 
-            if self.operation_mode == "shared":
-                if self.start_address:
-                    cmd.append(f"--start-address={self.start_address}")
-                if self.end_address:
-                    cmd.append(f"--end-address={self.end_address}")
-                if self.subnet_mask:
-                    cmd.append(f"--subnet-mask={self.subnet_mask}")
-            elif self.operation_mode == "bridged":
-                cmd.append(f"--shared-interface={self.shared_interface}")
-            elif self.operation_mode == "host":
-                if self.start_address:
-                    cmd.append(f"--start-address={self.start_address}")
-                if self.end_address:
-                    cmd.append(f"--end-address={self.end_address}")
-                if self.subnet_mask:
-                    cmd.append(f"--subnet-mask={self.subnet_mask}")
-                if self.enable_isolation:
-                    cmd.append("--enable-isolation")
-            else:
-                raise RuntimeError(f"invalid operation mode: {self.operation_mode}")
+        if self.start_address:
+            cmd.append(f"--start-address={self.start_address}")
+
+        if self.end_address:
+            cmd.append(f"--end-address={self.end_address}")
+
+        if self.subnet_mask:
+            cmd.append(f"--subnet-mask={self.subnet_mask}")
+
+        if self.enable_isolation:
+            cmd.append("--enable-isolation")
+
+        if self.shared_interface:
+            cmd.append(f"--shared-interface={self.shared_interface}")
 
         if self.enable_offloading:
             cmd.extend(["--enable-tso", "--enable-checksum-offload"])

--- a/vmnet/helper_test.py
+++ b/vmnet/helper_test.py
@@ -164,6 +164,16 @@ class TestStart:
             self.check_interface(h.interface)
             self.check_specific_network(h)
 
+    def test_shared_mode_isolated(self):
+        """
+        Test starting helper in shared mode with isolation
+        """
+        with run_helper(
+            operation_mode="shared",
+            enable_isolation=True,
+        ) as (h, sock):
+            self.check_interface(h.interface)
+
     def test_host_mode(self):
         """
         Test starting helper in host mode

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -308,9 +308,9 @@ class VM:
             cmd.append("--enable-isolation")
         if self.args.shared_interface:
             cmd.append(f"--shared-interface={self.args.shared_interface}")
-        if self.args.enable_offloading:
+        if self.enable_offloading:
             cmd.extend(["--enable-tso", "--enable-checksum-offload"])
-        if self.args.verbose:
+        if self.verbose:
             cmd.append("--verbose")
         cmd.append("--")
         cmd.extend(vm_command)

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -296,13 +296,19 @@ class VM:
         cmd = [self.runner]
         if self.args.network_name:
             cmd.append(f"--network={self.args.network_name}")
-        elif self.args.operation_mode:
+        if self.args.operation_mode:
             cmd.append(f"--operation-mode={self.args.operation_mode}")
-            if self.args.operation_mode == "bridged":
-                cmd.append(f"--shared-interface={self.args.shared_interface}")
-            elif self.args.operation_mode == "host" and self.args.enable_isolation:
-                cmd.append("--enable-isolation")
-        if self.enable_offloading:
+        if self.args.start_address:
+            cmd.append(f"--start-address={self.args.start_address}")
+        if self.args.end_address:
+            cmd.append(f"--end-address={self.args.end_address}")
+        if self.args.subnet_mask:
+            cmd.append(f"--subnet-mask={self.args.subnet_mask}")
+        if self.args.enable_isolation:
+            cmd.append("--enable-isolation")
+        if self.args.shared_interface:
+            cmd.append(f"--shared-interface={self.args.shared_interface}")
+        if self.args.enable_offloading:
             cmd.extend(["--enable-tso", "--enable-checksum-offload"])
         if self.args.verbose:
             cmd.append("--verbose")


### PR DESCRIPTION
Simplify vmnet options handling by treating shared and host mode
uniformly, and allow `--enable-isolation` in shared mode.

Changes:

- **vmnet/vm, vmnet/helper**: Remove mode-specific logic that passed
  certain options only in certain modes. The caller, runner, and helper
  already validate the options, so we now pass all set options
  unconditionally. Also adds the missing address options to the runner.

- **helper**: Merge the shared and host mode cases in the debug logging
  and XPC dictionary setup, since they now use the same options.

- **options, runner, example**: Change validation to reject
  `--enable-isolation` only for bridged mode instead of requiring host
  mode. Remove the check requiring `--operation-mode` when using address
  options, since the helper defaults to shared mode.

- **docs**: Move --enable-isolation to its own section instead since this
  works now with both host and shared modes.

- **tests**: Add `test_shared_mode_isolated`.

Fixes #148 
Fixes #149 