### PR TITLE
cidata: Reuse cloud-init iso across boots

### DIFF
--- a/vmnet/cidata.py
+++ b/vmnet/cidata.py
@@ -42,11 +42,16 @@ def create_iso(vm):
     """
     Create cloud-init iso image.
 
-    We create a new cidata.iso with new instance id for every run to update the
-    vm network configuration and install avahi for mDNS discovery.
+    The iso is created on first run and reused on subsequent runs so
+    cloud-init skips re-provisioning. Delete the iso to force recreation.
     """
     vm_home = store.vm_path(vm.vm_name)
     cidata = os.path.join(vm_home, "cidata.iso")
+
+    if os.path.exists(cidata):
+        logging.debug("Reusing cloud-init iso '%s'", cidata)
+        return cidata
+
     create_user_data(vm)
     create_meta_data(vm)
     create_network_config(vm)


### PR DESCRIPTION
Skip iso creation if cidata.iso already exists. This keeps the same instance-id across boots, so cloud-init treats subsequent boots as re-boots and skips re-provisioning (package installs, runcmd, etc.).

Delete the iso to force recreation.

Example first boot (creating the iso):

    % ./example server
    [   0.045] INFO Starting vmnet-helper for 'server' ...
    [   0.065] INFO Creating cloud-init iso '...cidata.iso'
    [   0.072] INFO Starting 'vfkit' virtual machine 'server' ...
    [   5.125] INFO Virtual machine IP address: 192.168.105.20

Example subsequent boot (reusing the iso):

    % ./example server
    [   0.046] INFO Starting vmnet-helper for 'server' ...
    [   0.065] INFO Starting 'vfkit' virtual machine 'server' ...
    [   4.097] INFO Virtual machine IP address: 192.168.105.20

Fixes: #182