### PR TITLE
test: Use mDNS name instead of IP address

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -69,9 +69,8 @@ jobs:
               --verbose &
           pid=$!
           echo $pid > test.pid
-          vm="$HOME/.vmnet-helper/vms/test"
-          if ! timeout 300s bash -c "until test -f $vm/ip-address; do sleep 3; done"; then
-              echo >&2 "Timeout waiting for $vm/ip-address"
+          if ! timeout 300s bash -c "until nc -z test-vmnet-helper.local 22 2>/dev/null; do true; done"; then
+              echo >&2 "Timeout waiting for test-vmnet-helper.local"
               exit 1
           fi
       - name: Inspect VM host data
@@ -89,14 +88,12 @@ jobs:
           sudo head -n 500 /var/db/dhcpd_leases || true
       - name: Inspect VM guest data
         run: |
-          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
-          ssh_cmd="ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -l ubuntu $vm_ip"
+          ssh_cmd="ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -l ubuntu test-vmnet-helper.local"
           echo "uname: $($ssh_cmd uname -a)"
           echo "cmdline: $($ssh_cmd cat /proc/cmdline)"
       - name: Prepare example VM
         run: |
-          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
-          ssh_cmd="ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -l ubuntu $vm_ip"
+          ssh_cmd="ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -l ubuntu test-vmnet-helper.local"
           $ssh_cmd sudo apt-get update -y
           $ssh_cmd sudo DEBIAN_FRONTEND=noninteractive apt-get install -y iperf3
           $ssh_cmd sudo systemctl start iperf3.service
@@ -110,12 +107,10 @@ jobs:
           echo "iperf3 server is ready"
       - name: Run iperf3 (host to vm)
         run: |
-          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
-          iperf3-darwin -c $vm_ip
+          iperf3-darwin -c test-vmnet-helper.local
       - name: Run iperf3 (vm to host)
         run: |
-          vm_ip=$(cat $HOME/.vmnet-helper/vms/test/ip-address)
-          iperf3-darwin -c $vm_ip --reverse
+          iperf3-darwin -c test-vmnet-helper.local --reverse
       - name: Terminate example VM
         run: |
           pid=$(cat test.pid)

--- a/bench
+++ b/bench
@@ -8,6 +8,7 @@ import glob
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import time
@@ -55,8 +56,8 @@ def do_create(args):
     try:
         client.start()
         try:
-            server.wait_for_ip_address()
-            client.wait_for_ip_address()
+            server.wait_until_ready()
+            client.wait_until_ready()
             install_iperf3(server)
             install_iperf3(client)
             enable_iperf3_service(server)
@@ -185,6 +186,9 @@ class VM:
         self.proc = None
         self.ip_address = None
 
+    def fqdn(self):
+        return f"{self.name}-vmnet-helper.local"
+
     def start(self):
         print(f"Starting {self.name}")
         cmd = [
@@ -203,22 +207,23 @@ class VM:
         print(f"Starting process {cmd}")
         self.proc = subprocess.Popen(cmd)
 
-    def wait_for_ip_address(self, timeout=60):
-        print(f"Waiting for {self.name} ip address")
+    def wait_until_ready(self, timeout=60):
+        print(f"Waiting for {self.name} to become ready")
         deadline = time.monotonic() + timeout
-        path = vmnet.vm_path(self.name, "ip-address")
-        while True:
-            if os.path.exists(path):
-                with open(path) as f:
-                    self.ip_address = f.readline().strip()
-                break
-            if time.monotonic() > deadline:
-                raise RuntimeError(f"Timeout waiting for {self.name} ip address")
+        fqdn = self.fqdn()
+        while time.monotonic() < deadline:
             if self.proc.poll() is not None:
                 raise RuntimeError(
                     f"{self.name} terminated (exitcode={self.proc.returncode})"
                 )
+            try:
+                with socket.create_connection((fqdn, 22), timeout=1):
+                    self.ip_address = socket.gethostbyname(fqdn)
+                    return
+            except OSError:
+                pass
             time.sleep(1)
+        raise RuntimeError(f"Timeout waiting for {self.name}")
 
     def stop(self):
         print(f"Stopping {self.name}")
@@ -274,10 +279,10 @@ def run(operation_mode, driver, config):
         # an ip address before starting the client avoids this.  TODO: Until we
         # find a real fix, try to wait until the server helper is ready or a
         # short sleep.
-        server.wait_for_ip_address()
+        server.wait_until_ready()
         client.start()
         try:
-            client.wait_for_ip_address()
+            client.wait_until_ready()
             for test in config["tests"]:
                 run_test(config_name, test, server, client, config)
         finally:

--- a/example
+++ b/example
@@ -206,7 +206,7 @@ def run_with_fd(args):
         )
         vm.start()
         try:
-            vm.wait_for_ip_address(timeout=args.timeout)
+            vm.wait_until_ready(timeout=args.timeout)
             os.wait()
         finally:
             vm.stop()
@@ -231,7 +231,7 @@ def run_with_socket(args):
         vm = vmnet.VM(args, helper.interface[vmnet.VMNET_MAC_ADDRESS], socket=socket)
         vm.start()
         try:
-            vm.wait_for_ip_address(timeout=args.timeout)
+            vm.wait_until_ready(timeout=args.timeout)
             os.wait()
         finally:
             vm.stop()
@@ -246,7 +246,7 @@ def run_with_runner(args):
     vm = vmnet.VM(args, vmnet.mac_address_from(args.vm_name), fd=4, runner=vmnet.RUNNER)
     vm.start()
     try:
-        vm.wait_for_ip_address(timeout=args.timeout)
+        vm.wait_until_ready(timeout=args.timeout)
         os.wait()
     finally:
         vm.stop()

--- a/vmnet/ssh.py
+++ b/vmnet/ssh.py
@@ -14,7 +14,7 @@ Host {vm.vm_name}
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   User {vm.distro}
-  Hostname {vm.ip_address}
+  Hostname {vm.fqdn()}
 """
     path = config_path(vm)
     with open(path, "w") as f:

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -50,7 +50,6 @@ class VM:
         self.disk = None
         self.cidata = None
         self.proc = None
-        self.ip_address = None
 
     def start(self):
         """
@@ -76,6 +75,7 @@ class VM:
             self.mac_address,
         )
         store.silent_remove(self.serial)
+        ssh.create_config(self)
         self._start_process(cmd)
 
     def _start_process(self, cmd):
@@ -97,7 +97,6 @@ class VM:
             )
 
     def stop(self):
-        self.delete_ip_address()
         ssh.delete_config(self)
         self.proc.terminate()
         self.proc.wait()
@@ -128,54 +127,32 @@ class VM:
         """
         return f"{self.hostname()}.local"
 
-    def wait_for_ip_address(self, timeout=60):
+    def wait_until_ready(self, timeout=60):
         """
-        Resolve the VM hostname via mDNS and wait until it is reachable.
+        Wait until the VM is reachable via mDNS on the SSH port.
         """
         deadline = time.monotonic() + timeout
+        address = self.fqdn()
+        logging.debug("Waiting until VM is ready at %s", address)
+
         while time.monotonic() < deadline:
-            self.check_running()
-            ip = self._connect_to_guest(self.fqdn())
-            if ip:
-                self.ip_address = ip
-                logging.info("Virtual machine IP address: %s", ip)
-                self.write_ip_address()
-                ssh.create_config(self)
-                return
-            time.sleep(1)
+            try:
+                # mDNS resolution times out in 5 seconds if the name is unknown.
+                with socket.create_connection((address, 22), timeout=5):
+                    logging.info("VM is ready at %s", address)
+                    return
+            except OSError as e:
+                self.check_running()
+                logging.debug("Connect %s: %s", address, e)
+
         self.check_running()
         logging.warning("Timeout waiting for vm to become reachable")
-
-    def _connect_to_guest(self, hostname, port=22):
-        """
-        Resolve hostname and verify the VM is reachable on the SSH port.
-        """
-        try:
-            ip = socket.gethostbyname(hostname)
-        except socket.gaierror as e:
-            logging.debug("mDNS lookup '%s': %s", hostname, e)
-            return None
-        try:
-            with socket.create_connection((ip, port), timeout=1):
-                return ip
-        except OSError as e:
-            logging.debug("Connect %s:%s: %s", ip, port, e)
-            return None
 
     def check_running(self):
         if self.proc.poll() is not None:
             raise RuntimeError(
                 f"Virtual machine terminated (exitcode {self.proc.returncode})"
             )
-
-    def write_ip_address(self):
-        path = store.vm_path(self.vm_name, "ip-address")
-        with open(path, "w") as f:
-            f.write(self.ip_address)
-
-    def delete_ip_address(self):
-        path = store.vm_path(self.vm_name, "ip-address")
-        store.silent_remove(path)
 
     def vfkit_command(self):
         efi_store = store.vm_path(self.vm_name, "efi-variable-store")


### PR DESCRIPTION
Since we use mDNS to discover VMs, we don't need to resolve and store
the IP address — we can use the mDNS name directly. This removes the
ip-address file, simplifies the wait logic to a single blocking
connect() call, and lets us create the SSH config at start time since
the address is known upfront.

Changes:
- Use the VM mDNS name directly instead of discovering and storing the
  IP address. The ip-address file and related code are removed.
- SSH config is created at start time since the mDNS address is known
  upfront.
- Wait for VM readiness using a single blocking `connect()` with a
  5-second timeout, matching the mDNS resolution timeout. No polling
  or sleep needed.
- CI uses `nc -z` with the mDNS name instead of polling for the
  ip-address file.
- Bench resolves the IP on connect for use in SSH and iperf3, since
  mDNS resolution may not be available inside guest VMs.