### PR TITLE
disks: Skip kernel and initrd download for non-qemu drivers

### DIFF
--- a/vmnet/disks.py
+++ b/vmnet/disks.py
@@ -58,20 +58,21 @@ def create_disk(vm):
         image = create_image(image_info["image"], format="raw", size="20g")
         logging.info("Creating image '%s'", disk["image"])
         clone(image, disk["image"])
-    if "kernel" in image_info:
-        disk["kernel"] = store.vm_path(vm.vm_name, "kernel")
-        if not os.path.isfile(disk["kernel"]):
-            kernel = create_image(image_info["kernel"])
-            logging.info("Creating kernel '%s'", disk["kernel"])
-            clone(kernel, disk["kernel"])
-    if "initrd" in image_info:
-        disk["initrd"] = store.vm_path(vm.vm_name, "initrd")
-        if not os.path.isfile(disk["initrd"]):
-            initrd = create_image(image_info["initrd"])
-            logging.info("Creating initrd '%s'", disk["initrd"])
-            clone(initrd, disk["initrd"])
-    if "kernel_parameters" in image_info:
-        disk["kernel_parameters"] = image_info["kernel_parameters"]
+    if vm.supports_kernel_boot():
+        if "kernel" in image_info:
+            disk["kernel"] = store.vm_path(vm.vm_name, "kernel")
+            if not os.path.isfile(disk["kernel"]):
+                kernel = create_image(image_info["kernel"])
+                logging.info("Creating kernel '%s'", disk["kernel"])
+                clone(kernel, disk["kernel"])
+        if "initrd" in image_info:
+            disk["initrd"] = store.vm_path(vm.vm_name, "initrd")
+            if not os.path.isfile(disk["initrd"]):
+                initrd = create_image(image_info["initrd"])
+                logging.info("Creating initrd '%s'", disk["initrd"])
+                clone(initrd, disk["initrd"])
+        if "kernel_parameters" in image_info:
+            disk["kernel_parameters"] = image_info["kernel_parameters"]
     return disk
 
 

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -127,6 +127,9 @@ class VM:
         """
         return f"{self.hostname()}.local"
 
+    def supports_kernel_boot(self):
+        return self.driver == "qemu"
+
     def wait_until_ready(self, timeout=60):
         """
         Wait until the VM is reachable via mDNS on the SSH port.


### PR DESCRIPTION
Only download kernel and initrd when the driver supports kernel boot (qemu). vfkit and krunkit boot from EFI firmware and don't need them.

On x86_64 CI runners this avoids ~3 seconds of unnecessary downloads and removes noise from the logs.

Fixes: #228