### PR TITLE
ci: Disable Spotlight indexing on macOS runners

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -30,6 +30,12 @@ jobs:
           uname -a
           sw_vers
           ifconfig
+      - name: Disable spotlight indexing
+        run: |
+          # Disable indexing globally
+          sudo mdutil -a -i off
+          # Erase Existing Indexes
+          sudo mdutil -E /
       - name: Install requirements
         run: brew install meson qemu cdrtools coreutils tree
       - name: Inspect qemu

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,12 @@ jobs:
         run: |
           uname -a
           sw_vers
+      - name: Disable spotlight indexing
+        run: |
+          # Disable indexing globally
+          sudo mdutil -a -i off
+          # Erase Existing Indexes
+          sudo mdutil -E /
       - name: Checkout source
         uses: actions/checkout@v6
       - name: Ensure tag


### PR DESCRIPTION
Spotlight indexing causes unnecessary CPU and I/O load when downloading large images or building, making CI jobs slower and less stable.