### PR TITLE
ci: Run tests only on pull requests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,9 +6,6 @@ name: Test
 
 on:
   pull_request:
-  push:
-    branches:
-    - main
   schedule:
     - cron: '0 3 * * 0' # runs job at 3AM every sunday
 


### PR DESCRIPTION
Tests already run on every PR, so re-running them after merge to main wastes CI time. The weekly schedule still catches regressions from external changes like new macOS images.