### PR TITLE
ci: Use build artifact in integration tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -37,7 +37,7 @@ jobs:
           # Erase Existing Indexes
           sudo mdutil -E /
       - name: Install requirements
-        run: brew install meson qemu cdrtools coreutils tree
+        run: brew install qemu cdrtools coreutils tree
       - name: Inspect qemu
         # Looking up both prefixes to make it eaier to port to arm64 in the future.
         run: |
@@ -48,10 +48,14 @@ jobs:
         run: brew install vfkit
       - name: Checkout source
         uses: actions/checkout@v6
-      - name: Build vmnet-helper
-        run: ./build.sh build
+      - name: Download build artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: vmnet-helper.tar.gz
       - name: Install vmnet-helper
-        run: VMNET_INTERACTIVE=0 ./install.sh build/vmnet-helper.tar.gz
+        run: VMNET_INTERACTIVE=0 ./install.sh vmnet-helper.tar.gz
+      - name: Print version
+        run: /opt/vmnet-helper/bin/vmnet-helper --version
       - name: Ensure public key
         run: |
           ssh-keygen -q -N "" </dev/zero

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,17 @@ jobs:
         uses: actions/checkout@v6
       - name: Ensure tag
         # Archiving requires a tag, but we checkout only the last commit.
-        run: git describe --tags 2>/dev/null || git tag devel
+        run: |
+          if ! git describe --tags 2>/dev/null; then
+            pr_number="${{ github.event.pull_request.number }}"
+            run_id="${{ github.run_id }}"
+            attempt="${{ github.run_attempt }}"
+            if [ -n "$pr_number" ]; then
+              git tag "pr-${pr_number}-${run_id}-${attempt}"
+            else
+              git tag "scheduled-${run_id}-${attempt}"
+            fi
+          fi
       - name: Install requirements
         run: brew install meson
       - name: Build
@@ -62,6 +72,13 @@ jobs:
         run: |
           source .venv/bin/activate
           pytest -v --log-cli-level=debug
+      - name: Upload build artifact
+        if: matrix.os == 'macos-26'
+        uses: actions/upload-artifact@v7
+        with:
+          name: vmnet-helper.tar.gz
+          path: build/vmnet-helper.tar.gz
+          compression-level: 0
 
   integration:
     needs: test


### PR DESCRIPTION
Build vmnet-helper once in the test job on macOS 26 (fat binary) and upload it as an artifact. Integration tests download and install the pre-built artifact instead of building from source.

### Why

This ensures we test the same fat binary we release. Previously the integration job built its own binary from a shallow checkout without tags, resulting in `vmnet-helper unknown` version. Now the binary is built once with a proper version tag and reused across all integration jobs.

### Build traceability

Build tags include the PR number, run ID, and attempt number for traceability:
- PR run: `pr-233-24585886333-2`
- Scheduled run: `scheduled-{run_id}-{attempt}`

The installed version is logged in integration jobs:
```
running /opt/vmnet-helper/bin/vmnet-helper pr-233-24585886333-1 on macOS 15.7.5
```

### Downloadable artifacts

PR build artifacts are downloadable by users from the Actions page, making it easy to test PR builds without building from source.

### Notes

The artifact is uploaded with `compression-level: 0` since the tarball is already compressed. `upload-artifact@v7` supports `archive: false` to skip the zip wrapper entirely, but `download-artifact@v7` fails to download unarchived artifacts.

Fixes: #230
Fixes: #98