### PR TITLE
Simplfy cloud-init configuration and fix networking issue with alpine

### DIFF
--- a/vmnet/cidata.py
+++ b/vmnet/cidata.py
@@ -119,11 +119,10 @@ def create_network_config(vm):
     data = {
         "version": 2,
         "ethernets": {
-            "vmnet0": {
+            "eth0": {
                 "match": {
                     "macaddress": vm.mac_address,
                 },
-                "set-name": "vmnet0",
                 "dhcp4": True,
                 "dhcp-identifier": "mac",
                 "dhcp4-overrides": {

--- a/vmnet/cidata.py
+++ b/vmnet/cidata.py
@@ -25,12 +25,18 @@ DISTROS = {
     },
     "alpine": {
         "packages": ["avahi"],
-        # Alpine needs dbus in the default runlevel — avahi depends on it
-        # but `apk add avahi` does not enable it. Add both to the default
-        # runlevel for subsequent boots. Start dbus explicitly before avahi
-        # because OpenRC dependency resolution does not work during
-        # cloud-init runcmd.
         "runcmd": [
+            # Fix dhcpcd to use MAC client identifier instead of
+            # DUID+IAID, and restart to release the bad first boot
+            # lease. https://github.com/nirs/vmnet-helper/issues/54
+            "sed -i 's/^duid/clientid/' /etc/dhcpcd.conf",
+            "dhcpcd --release eth0",
+            "rc-service dhcpcd restart",
+            # Enable and start avahi-daemon. dbus must be added
+            # explicitly — avahi depends on it but `apk add avahi`
+            # does not enable it. Start dbus before avahi because
+            # OpenRC dependency resolution does not work during
+            # cloud-init runcmd.
             "rc-update add dbus",
             "rc-update add avahi-daemon",
             "rc-service dbus start",

--- a/vmnet/cidata.py
+++ b/vmnet/cidata.py
@@ -11,29 +11,31 @@ import yaml
 
 from . import store
 
-# Distro-specific package names and optional enable commands.
-PACKAGES = {
-    "avahi": {
-        # Ubuntu auto-enables and starts daemons on package install.
-        "ubuntu": {"name": "avahi-daemon"},
-        "fedora": {
-            "name": "avahi",
-            "runcmd": ["systemctl enable --now avahi-daemon"],
-        },
+# Distro-specific cloud-init user-data configuration. Keys match
+# cloud-init module names so the dict can be merged directly into the
+# user-data.
+DISTROS = {
+    # Ubuntu auto-enables and starts daemons on package install.
+    "ubuntu": {
+        "packages": ["avahi-daemon"],
+    },
+    "fedora": {
+        "packages": ["avahi"],
+        "runcmd": ["systemctl enable --now avahi-daemon"],
+    },
+    "alpine": {
+        "packages": ["avahi"],
         # Alpine needs dbus in the default runlevel — avahi depends on it
         # but `apk add avahi` does not enable it. Add both to the default
         # runlevel for subsequent boots. Start dbus explicitly before avahi
         # because OpenRC dependency resolution does not work during
         # cloud-init runcmd.
-        "alpine": {
-            "name": "avahi",
-            "runcmd": [
-                "rc-update add dbus",
-                "rc-update add avahi-daemon",
-                "rc-service dbus start",
-                "rc-service avahi-daemon start",
-            ],
-        },
+        "runcmd": [
+            "rc-update add dbus",
+            "rc-update add avahi-daemon",
+            "rc-service dbus start",
+            "rc-service avahi-daemon start",
+        ],
     },
 }
 
@@ -82,17 +84,14 @@ def create_user_data(vm):
     """
     Create cloud-init user-data file.
     """
-    avahi_pkg = PACKAGES["avahi"][vm.distro]
     data = {
         "password": "password",
         "chpasswd": {
             "expire": False,
         },
         "ssh_authorized_keys": public_keys(),
-        "packages": [avahi_pkg["name"]],
     }
-    if "runcmd" in avahi_pkg:
-        data["runcmd"] = avahi_pkg["runcmd"]
+    data.update(DISTROS[vm.distro])
 
     path = store.vm_path(vm.vm_name, "user-data")
     with open(path, "w") as f:

--- a/vmnet/disks.py
+++ b/vmnet/disks.py
@@ -37,7 +37,7 @@ IMAGES = {
     },
     "alpine": {
         "arm64": {
-            "image": "https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/cloud/nocloud_alpine-3.21.2-aarch64-uefi-cloudinit-r0.qcow2",
+            "image": "https://dl-cdn.alpinelinux.org/alpine/v3.23/releases/cloud/nocloud_alpine-3.23.3-aarch64-uefi-cloudinit-r0.qcow2",
         },
     },
     "fedora": {


### PR DESCRIPTION
- Simplify the way we careate user-data using DISTROS dict.

- Update alpine image to latest release (3.23.3)

- The network-config used `set-name: vmnet0` to rename the interface,
  but Alpine's cloud-init ENI renderer doesn't support this. It wrote
  `auto vmnet0` into /etc/network/interfaces while the kernel interface
  stayed `eth0`, breaking networking on the second boot. Removed the
  rename — Ubuntu and Fedora match by MAC address so the key name
  doesn't matter.

- Alpine's dhcpcd defaults to DUID+IAID as the DHCP client identifier,
  ignoring cloud-init's `dhcp-identifier: mac` setting. The DUID
  includes a timestamp, causing a new IP on every boot. Fixed by
  switching dhcpcd.conf to `clientid` via runcmd and restarting dhcpcd
  to release the bad first boot lease.

Tested first and second boots on Alpine, Ubuntu, and Fedora.

Fixes #54