### PR TITLE
ssh: create config once like disk and cidata

### DIFF
--- a/vmnet/ssh.py
+++ b/vmnet/ssh.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: The vmnet-helper authors
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+import os
+
 from . import store
 
 
@@ -9,6 +12,11 @@ def config_path(vm):
 
 
 def create_config(vm):
+    path = config_path(vm)
+    if os.path.exists(path):
+        logging.debug("Reusing ssh config '%s'", path)
+        return
+
     data = f"""
 Host {vm.vm_name}
   StrictHostKeyChecking no
@@ -16,11 +24,6 @@ Host {vm.vm_name}
   User {vm.distro}
   Hostname {vm.fqdn()}
 """
-    path = config_path(vm)
+    logging.info("Creating ssh config '%s'", path)
     with open(path, "w") as f:
         f.write(data)
-
-
-def delete_config(vm):
-    path = config_path(vm)
-    store.silent_remove(path)

--- a/vmnet/vm.py
+++ b/vmnet/vm.py
@@ -97,7 +97,6 @@ class VM:
             )
 
     def stop(self):
-        ssh.delete_config(self)
         self.proc.terminate()
         self.proc.wait()
 


### PR DESCRIPTION
The ssh config was deleted on every stop and recreated on every start. When starting without --distro, the config was overwritten with the default distro user, breaking ssh access.

Create the config once on first start and reuse it on subsequent starts, matching the pattern used for disk and cidata.iso.

Example:

    % ./example fedora --distro fedora -v
    ...
    [   0.057] DEBUG Reusing ssh config '/Users/nir/.vmnet-helper/vms/fedora/ssh.config'