### PR TITLE
Update documentation examples to reflect the current state of the project

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -24,14 +24,15 @@ To start a virtual machine using *vfkit* run:
 
 ```console
 % ./example vm
-Starting vmnet-helper for 'vm' with interface id '391ea262-d812-45b9-9526-e0ab5aeff7a2'
-Downloading image 'https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-arm64.img'
-Converting image to raw format '/Users/nir/.vmnet-helper/cache/images/fe0930aca80e74ef9bcdc6e883fd6d716f490f765c8848d90f1d9c9cf69c43b2/disk.img'
-Resizing image to 20g
-Creating disk '/Users/nir/.vmnet-helper/vms/vm/disk.img'
-Creating cloud-init iso '/Users/nir/.vmnet-helper/vms/vm/cidata.iso'
-Starting 'vfkit' virtual machine 'vm' with mac address 'a2:89:b2:31:d7:fb'
-Virtual machine IP address:  192.168.64.2
+[   0.038] INFO Starting vmnet-helper for 'vm' with interface id '391ea262-d812-45b9-9526-e0ab5aeff7a2'
+[   0.058] INFO Downloading image 'https://cloud-images.ubuntu.com/releases/25.04/release/ubuntu-25.04-server-cloudimg-arm64.img'
+[  19.384] INFO Converting image to 'raw' format '/Users/nir/.vmnet-helper/cache/images/7fef961f75d830af5d20db6da02bff7e33ce662a49bd4b433ed8f35a9f6a18c0/data'
+[  21.558] INFO Resizing image to 20g
+[  21.585] INFO Creating image '/Users/nir/.vmnet-helper/vms/vm/disk.img'
+[  21.591] INFO Creating cloud-init iso '/Users/nir/.vmnet-helper/vms/vm/cidata.iso'
+[  21.597] INFO Starting 'vfkit' virtual machine 'vm' with mac address 'a2:89:b2:31:d7:fb'
+[  21.598] INFO Creating ssh config '/Users/nir/.vmnet-helper/vms/vm/ssh.config'
+[  36.842] INFO VM is ready at vm-vmnet-helper.local
 ```
 
 To stop the virtual machine and the vmnet-helper press *Control+C*.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -5,6 +5,40 @@ SPDX-License-Identifier: Apache-2.0
 
 # Integration
 
+## Install location
+
+On **macOS 26** and later, vmnet-helper is installed via Homebrew.
+Use `brew --prefix vmnet-helper` to get the install prefix:
+
+```console
+$(brew --prefix vmnet-helper)/libexec/vmnet-helper
+$(brew --prefix vmnet-helper)/libexec/vmnet-run
+```
+
+On **macOS 15** and earlier, vmnet-helper is installed at a fixed
+location by the install script:
+
+```
+/opt/vmnet-helper/bin/vmnet-helper
+/opt/vmnet-helper/bin/vmnet-run
+```
+
+> [!NOTE]
+> The examples in this guide use macOS 26 with Homebrew paths.
+
+## Running with sudo
+
+On **macOS 26** and later, vmnet-helper runs as a regular user — do
+not use `sudo`.
+
+On **macOS 15** and earlier, vmnet-helper requires root privileges.
+See the [sudo guide](/docs/sudo.md) for details on using `sudo` with
+vmnet-helper.
+
+> [!NOTE]
+> The examples in this guide do not use `sudo`. Add `sudo` when
+> running on macOS 15 and earlier.
+
 ## Starting the helper with a file descriptor
 
 > [!NOTE]

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -24,20 +24,20 @@ virtual machine.
 Example run using jq to pretty print the response:
 
 ```console
-% sudo --non-interactive \
-       --close-from 4 \
-       /opt/vmnet-helper/bin/vmnet-helper \
-       --fd 3 \
-       --interface-id 2835E074-9892-4A79-AFFB-7E41D2605678 \
-       2>/dev/null | jq
+% $(brew --prefix vmnet-helper)/libexec/vmnet-helper \
+    --fd 3 \
+    --interface-id 2835E074-9892-4A79-AFFB-7E41D2605678 \
+    2>/dev/null | jq
 {
+  "vmnet_write_max_packets": 256,
+  "vmnet_read_max_packets": 256,
   "vmnet_subnet_mask": "255.255.255.0",
   "vmnet_mtu": 1500,
-  "vmnet_end_address": "192.168.64.254",
-  "vmnet_start_address": "192.168.64.1",
+  "vmnet_end_address": "192.168.105.254",
+  "vmnet_start_address": "192.168.105.1",
   "vmnet_interface_id": "2835E074-9892-4A79-AFFB-7E41D2605678",
   "vmnet_max_packet_size": 1514,
-  "vmnet_nat66_prefix": "fd9b:5a14:ba57:e3d3::",
+  "vmnet_nat66_prefix": "fd2d:1b24:620:47::",
   "vmnet_mac_address": "0a:d6:36:c1:ea:f3"
 }
 ```
@@ -58,25 +58,25 @@ support passing a file descriptor, you can use a bound unix socket.
 Example run with a unix socket, redirecting the helper stdout to file:
 
 ```console
-% sudo --non-interactive \
-       /opt/vmnet-helper/bin/vmnet-helper \
-       --socket /tmp/example/vm/vmnet.sock \
-       --interface-id 2835E074-9892-4A79-AFFB-7E41D2605678 \
-       >/tmp/example/vm/vmnet.json
-INFO  [main] running /opt/vmnet-helper/bin/vmnet-helper v0.2.0-4-ga1b610b on macOS 15.2.0
+% $(brew --prefix vmnet-helper)/libexec/vmnet-helper \
+    --socket /tmp/vmnet-helper.sock \
+    --interface-id 2835E074-9892-4A79-AFFB-7E41D2605678 \
+    >/tmp/vmnet-helper.json
+INFO  [main] running /opt/homebrew/opt/vmnet-helper/libexec/vmnet-helper v0.11.0 on macOS 26.4.0
+INFO  [main] running as uid: 501 gid: 20
 INFO  [main] enabling bulk forwarding
 INFO  [main] started vmnet interface
-INFO  [main] running as uid: 501 gid: 20
-INFO  [main] waiting for client on "/tmp/example/vm/vmnet.sock"
+INFO  [main] waiting for client on "/tmp/vmnet-helper.sock"
 ```
 
 The helper created a unix datagram socket and waits until a client
 connects and sends the first packet.
 
-You can get the mac address for the vm from the vmnet.json:
+You can get the mac address for the vm from the JSON file:
 
 ```console
-jq -r .vmnet_mac_address </tmp/example/vm/vmnet.json
+% jq -r .vmnet_mac_address </tmp/vmnet-helper.json
+0a:d6:36:c1:ea:f3
 ```
 
 ### Connecting to the helper unix socket
@@ -94,7 +94,7 @@ To connect to the helper from a client, you need to:
 When your client sends the first packet, the helper will start serving:
 
 ```console
-INFO  [main] serving client "/tmp/example/vm/vfkit-1262-6e38.sock"
+INFO  [main] serving client "/tmp/vfkit-1262-6e38.sock"
 INFO  [main] host forwarding started
 INFO  [main] vm forwarding started
 INFO  [main] waiting for termination
@@ -117,7 +117,7 @@ with one socket, and the command provided by the user with the other socket.
 Example run with *vfkit*:
 
 ```console
-/opt/vmnet-helper/bin/vmnet-run -- \
+$(brew --prefix vmnet-helper)/libexec/vmnet-run -- \
     vfkit \
     --bootloader=efi,variable-store=efi-variable-store,create \
     "--device=virtio-blk,path=disk.img" \
@@ -165,7 +165,7 @@ You can find the physical interfaces that can be used in bridged mode
 using the **--list-shared-interfaces** option.
 
 ```console
-% /opt/vmnet-helper/bin/vmnet-helper --list-shared-interfaces
+% $(brew --prefix vmnet-helper)/libexec/vmnet-helper --list-shared-interfaces
 en10
 en0
 ```
@@ -245,15 +245,15 @@ The `--interface-id` option is ignored in this mode.
 Example using vmnet-helper directly:
 
 ```console
-% /opt/vmnet-helper/bin/vmnet-helper \
-       --fd 3 \
-       --network shared
+% $(brew --prefix vmnet-helper)/libexec/vmnet-helper \
+    --fd 3 \
+    --network shared
 ```
 
 Example using vmnet-run:
 
 ```console
-/opt/vmnet-helper/bin/vmnet-run --network shared -- \
+$(brew --prefix vmnet-helper)/libexec/vmnet-run --network shared -- \
     vfkit \
     --bootloader=efi,variable-store=efi-variable-store,create \
     "--device=virtio-blk,path=disk.img" \

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -124,7 +124,6 @@ ethernets:
   eth0:
     match:
       macaddress: $MAC_ADDRESS
-    set-name: eth0
     dhcp4: true
     dhcp-identifier: mac
     dhcp4-overrides:

--- a/docs/sudo.md
+++ b/docs/sudo.md
@@ -1,0 +1,81 @@
+<!--
+SPDX-FileCopyrightText: The vmnet-helper authors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Running vment-helper with sudo
+
+On **macOS 26** and later, vmnet-helper runs as a regular user — do
+not use `sudo`.
+
+On **macOS 15** and earlier, vmnet-helper requires root privileges.
+See [sudoers.d](/sudoers.d/) for details on configuring sudoers for
+vmnet-helper.
+
+When running interactively, `sudo` will prompt for a password if
+needed:
+
+```console
+sudo /opt/vmnet-helper/bin/vmnet-helper --socket /tmp/vmnet-helper.sock ...
+```
+
+For automation, use `--non-interactive` to avoid hanging indefinitely
+waiting for a password. With `--non-interactive`, `sudo` fails
+immediately so you can handle the error:
+
+```console
+sudo --non-interactive \
+    /opt/vmnet-helper/bin/vmnet-helper --socket /tmp/vmnet-helper.sock ...
+```
+
+## Passing file descriptor with sudo
+
+When using `--fd`, you must use `--close-from` to prevent `sudo`
+from closing the file descriptor before the helper starts. By
+default, `sudo` closes all file descriptors above stderr (fd 2).
+`--close-from=4` keeps fd 3 open for the helper.
+
+```console
+sudo --close-from=4 /opt/vmnet-helper/bin/vmnet-helper --fd 3 ...
+```
+
+This requires the `closefrom_override` option in the sudoers
+configuration (enabled by the install script). See
+[sudoers.d](/sudoers.d/) for details.
+
+> [!WARNING]
+> On managed Macs where the sudoers configuration cannot be modified,
+> `--close-from` is not available and `--fd` cannot be used with
+> `sudo`. Use `--socket` instead. This is why [minikube always uses
+> `--socket`][minikube-vmnet].
+
+## Using passwordless sudo
+
+For smooth integration, the user should configure passwordless sudo
+during installation. However, passwordless sudo may not be available:
+
+- The user skipped the sudoers configuration during install
+- The machine policy prevents modifying sudoers (e.g. managed
+  corporate Macs)
+
+The `--non-interactive` option tells `sudo` to fail instead of
+prompting for a password. Use it to detect whether passwordless
+sudo is available, and fall back to a password prompt if not:
+
+1. Try `sudo --non-interactive vmnet-helper --version`
+2. If it succeeds, passwordless sudo is available — use
+   `sudo` to start the helper
+3. If it fails and interaction is possible, run `sudo --validate`
+   to prompt for a password and cache the credentials
+4. Start the helper with `sudo`, which now succeeds using the
+   cached credentials (valid for ~5 minutes)
+
+## Reference implementations
+
+- [run.c](/run.c) — vmnet-run's sudo handling, including
+  `--non-interactive`, `--close-from`, and `closefrom_override`
+- [minikube's vmnet integration][minikube-vmnet] — uses `--socket`
+  to avoid `closefrom_override`, and falls back to interactive
+  `sudo --validate` when passwordless sudo is not available
+
+[minikube-vmnet]: https://github.com/kubernetes/minikube/blob/799c248d9faccedf7fc6af377bb4464dbebf431f/pkg/drivers/common/vmnet/vmnet.go

--- a/examples/create-iso.sh
+++ b/examples/create-iso.sh
@@ -26,7 +26,6 @@ ethernets:
   eth0:
     match:
       macaddress: $MAC_ADDRESS
-    set-name: eth0
     dhcp4: true
     dhcp-identifier: mac
 EOF

--- a/examples/qemu.sh
+++ b/examples/qemu.sh
@@ -18,7 +18,7 @@ if [ ! -f "$CIDATA_ISO" ]; then
 fi
 
 # Start qemu and vmnet-helper connected via unix datagram sockets.
-/opt/vmnet-helper/bin/vmnet-run -- \
+$(brew --prefix vmnet-helper)/libexec/vmnet-run -- \
     qemu-system-aarch64 \
     -m 1024 \
     -cpu host \

--- a/examples/vfkit.sh
+++ b/examples/vfkit.sh
@@ -18,7 +18,7 @@ if [ ! -f "$CIDATA_ISO" ]; then
 fi
 
 # Start vfkit and vmnet-helper connected via unix datagram sockets.
-/opt/vmnet-helper/bin/vmnet-run -- \
+$(brew --prefix vmnet-helper)/libexec/vmnet-run -- \
     vfkit \
     --memory=1024 \
     --cpus=1 \


### PR DESCRIPTION
- Use `$(brew --prefix vmnet-helper)/libexec` paths instead of
  hardcoded `/opt/vmnet-helper/bin` (Homebrew install on macOS 26)
- Remove `sudo` from all example commands (no longer needed on macOS 26)
- Update example log output and JSON responses to current format
- Remove unnecessary `set-name` from launchd network-config example,
  matching the simplified network-config from #54