### PR TITLE
Fix x86_64 cross-compilation target triple

### DIFF
--- a/x86_64.ini
+++ b/x86_64.ini
@@ -12,5 +12,5 @@ c = 'clang'
 strip = 'strip'
 
 [built-in options]
-c_args = ['-target', 'arm64-apple-macos14.0', '-arch', 'x86_64']
-c_link_args = ['-target', 'arm64-apple-macos14.0', '-arch', 'x86_64']
+c_args = ['-target', 'x86_64-apple-macos14.0', '-arch', 'x86_64']
+c_link_args = ['-target', 'x86_64-apple-macos14.0', '-arch', 'x86_64']


### PR DESCRIPTION
The target triple in x86_64.ini was set to arm64-apple-macos14.0, which is incorrect for x86_64 cross-compilation. This worked because clang's -arch x86_64 flag overrides the architecture in the target triple, but it was confusing and misleading.

Use the correct x86_64-apple-macos14.0 target triple to match the actual target architecture.