### PR TITLE
docs: Remove --interface-id from vmnet-run examples

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,8 +124,6 @@ flowchart TB
 - **bridge100**: Host bridge for the subnet; typically has the subnet’s gateway IP (e.g. 192.168.64.1).
 
 Use the same subnet options for all VMs that should be on the same network.
-Use a stable `--interface-id` per VM so the MAC (and thus DHCP-assigned IP)
-stays the same across restarts.
 
 ## Native vmnet on macOS 26
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -76,13 +76,13 @@ Example run using jq to pretty print the response:
 }
 ```
 
+The `--interface-id` option is optional but recommended to ensure that
+vmnet allocates the same MAC address for the VM on every run.
+
 > [!TIP]
 > vmnet documentation instructs to configure the virtual interface with
 > the mac address specified by "vmnet_mac_address". Testing shows that
 > this is not required and any mac address works.
-
-The `--interface-id` option is optional. It ensures that you get the same
-MAC address on every run.
 
 ## Starting the helper with a unix socket
 
@@ -160,6 +160,12 @@ $(brew --prefix vmnet-helper)/libexec/vmnet-run -- \
 
 > [!IMPORTANT]
 > The command run by *vmnet-run* must use file descriptor 4.
+
+> [!NOTE]
+> The `--interface-id` option is not needed with vmnet-run. The command
+> passed to vmnet-run specifies its own MAC address (e.g.
+> `--device virtio-net,fd=4,mac=...`), so the MAC address allocated by
+> vmnet is not used.
 
 See the [examples](/examples/) for more examples of using *vmnet-run*.
 

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -148,13 +148,6 @@ Create the cloud-init ISO from the files:
 
 ### Creating the plist
 
-Generate a UUID for `--interface-id` to get stable MAC/IP assignments
-from vmnet across restarts:
-
-```console
-INTERFACE_ID=$(uuidgen)
-```
-
 > [!NOTE]
 > On macOS 15, replace the vmnet-run path in the plist with
 > `/opt/vmnet-helper/bin/vmnet-run`.
@@ -172,8 +165,6 @@ cat > ~/Library/LaunchAgents/local.$VM_NAME.plist << EOF
     <key>ProgramArguments</key>
     <array>
         <string>$(brew --prefix vmnet-helper)/libexec/vmnet-run</string>
-        <string>--interface-id</string>
-        <string>$INTERFACE_ID</string>
         <string>--</string>
         <string>$(brew --prefix)/bin/vfkit</string>
         <string>--cpus</string>


### PR DESCRIPTION
When using vmnet-run, the VM specifies its own MAC address (e.g. --device virtio-net,fd=4,mac=...) so the MAC address allocated by vmnet is not used. The --interface-id option is only useful when running vmnet-helper directly, where the caller can read the allocated MAC from the JSON response.

- launchd: Remove INTERFACE_ID generation and --interface-id from the plist example
- architecture: Remove --interface-id advice (not the right place for vmnet-run usage details)
- integration: Add a note that --interface-id is not needed with vmnet-run, and clarify that it is recommended when running vmnet-helper directly