### PR TITLE
Update to fedora 44

### DIFF
--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -38,13 +38,11 @@ Download a cloud image once and convert it to raw format. The cached
 image can be reused for multiple VMs.
 
 ```console
-curl --fail --location --output fedora-43.qcow2 \
-    https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-43-1.6.aarch64.qcow2
-
+curl --fail --location --output fedora-44.qcow2 \
+    https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-44-1.7.aarch64.qcow2
 mkdir -p ~/.cache/vm-images
-
-qemu-img convert -f qcow2 -O raw fedora-43.qcow2 \
-    ~/.cache/vm-images/fedora-43.img
+qemu-img convert -f qcow2 -O raw fedora-44.qcow2 \
+    ~/.cache/vm-images/fedora-44.img
 ```
 
 ## Creating a VM
@@ -63,7 +61,7 @@ and resize it:
 
 ```console
 mkdir -p ~/vms/$VM_NAME
-cp -c ~/.cache/vm-images/fedora-43.img ~/vms/$VM_NAME/disk.img
+cp -c ~/.cache/vm-images/fedora-44.img ~/vms/$VM_NAME/disk.img
 qemu-img resize -q -f raw ~/vms/$VM_NAME/disk.img 20g
 ```
 

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -42,15 +42,15 @@ brew install vmnet-helper vfkit krunkit cdrtools qemu
 Download a Fedora cloud image and convert to raw:
 
 > [!NOTE]
-> If you already have `~/.cache/vm-images/fedora-43.img` from the
+> If you already have `~/.cache/vm-images/fedora-44.img` from the
 > [launchd guide], skip this step.
 
 ```console
-curl --fail --location --output /tmp/fedora-43.qcow2 \
-    https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-43-1.6.aarch64.qcow2
+curl --fail --location --output /tmp/fedora-44.qcow2 \
+    https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-44-1.7.aarch64.qcow2
 mkdir -p ~/.cache/vm-images
-qemu-img convert -f qcow2 -O raw /tmp/fedora-43.qcow2 \
-    ~/.cache/vm-images/fedora-43.img
+qemu-img convert -f qcow2 -O raw /tmp/fedora-44.qcow2 \
+    ~/.cache/vm-images/fedora-44.img
 ```
 
 ## Creating podman VM with vfkit
@@ -74,7 +74,7 @@ print(':'.join(f'{x:02x}' for x in b))
 ")
 
 mkdir -p ~/vms/$VM_NAME
-cp -c ~/.cache/vm-images/fedora-43.img ~/vms/$VM_NAME/disk.img
+cp -c ~/.cache/vm-images/fedora-44.img ~/vms/$VM_NAME/disk.img
 qemu-img resize -q -f raw ~/vms/$VM_NAME/disk.img $DISK_SIZE
 
 cat > ~/vms/$VM_NAME/user-data << EOF
@@ -247,7 +247,7 @@ print(':'.join(f'{x:02x}' for x in b))
 ")
 
 mkdir -p ~/vms/$VM_NAME
-cp -c ~/.cache/vm-images/fedora-43.img ~/vms/$VM_NAME/disk.img
+cp -c ~/.cache/vm-images/fedora-44.img ~/vms/$VM_NAME/disk.img
 qemu-img resize -q -f raw ~/vms/$VM_NAME/disk.img $DISK_SIZE
 
 cat > ~/vms/$VM_NAME/user-data << EOF

--- a/testing/disks.py
+++ b/testing/disks.py
@@ -42,7 +42,7 @@ IMAGES = {
     },
     "fedora": {
         "arm64": {
-            "image": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-43-1.6.aarch64.qcow2",
+            "image": "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-44-1.7.aarch64.qcow2",
         },
     },
     "debian": {


### PR DESCRIPTION
Update to fedora 44

No change is needed, works like fedora 43. First tests show improved
performance in iperf3.

    % iperf3 -c fedora-vmnet-helper.local
    Connecting to host fedora-vmnet-helper.local, port 5201
    [  7] local 192.168.64.1 port 60692 connected to 192.168.64.8 port 5201
    [ ID] Interval           Transfer     Bitrate         Retr  Cwnd
    [  7]   0.00-1.00   sec  3.81 GBytes  32.8 Gbits/sec    5   8.00 MBytes
    [  7]   1.00-2.01   sec  4.67 GBytes  39.9 Gbits/sec    0   8.00 MBytes
    [  7]   2.01-3.01   sec  4.67 GBytes  40.1 Gbits/sec    0   8.00 MBytes
    [  7]   3.01-4.00   sec  4.53 GBytes  39.1 Gbits/sec   31   8.00 MBytes
    [  7]   4.00-5.00   sec  4.57 GBytes  39.3 Gbits/sec    0   8.00 MBytes
    [  7]   5.00-6.00   sec  4.70 GBytes  40.3 Gbits/sec    0   8.00 MBytes
    [  7]   6.00-7.01   sec  4.62 GBytes  39.6 Gbits/sec    0   8.00 MBytes
    [  7]   7.01-8.00   sec  4.58 GBytes  39.6 Gbits/sec    0   8.00 MBytes
    [  7]   8.00-9.00   sec  4.54 GBytes  39.0 Gbits/sec   42   8.00 MBytes
    [  7]   9.00-10.01  sec  4.65 GBytes  39.8 Gbits/sec   12   8.00 MBytes
    - - - - - - - - - - - - - - - - - - - - - - - - -
    [ ID] Interval           Transfer     Bitrate         Retr
    [  7]   0.00-10.01  sec  45.4 GBytes  38.9 Gbits/sec   90            sender
    [  7]   0.00-10.01  sec  45.4 GBytes  38.9 Gbits/sec                  receiver

    % iperf3 -c fedora-vmnet-helper.local -R
    Connecting to host fedora-vmnet-helper.local, port 5201
    Reverse mode, remote host fedora-vmnet-helper.local is sending
    [  7] local 192.168.64.1 port 60694 connected to 192.168.64.8 port 5201
    [ ID] Interval           Transfer     Bitrate
    [  7]   0.00-1.00   sec  5.53 GBytes  47.4 Gbits/sec
    [  7]   1.00-2.00   sec  5.61 GBytes  48.2 Gbits/sec
    [  7]   2.00-3.00   sec  5.63 GBytes  48.3 Gbits/sec
    [  7]   3.00-4.00   sec  5.59 GBytes  48.1 Gbits/sec
    [  7]   4.00-5.01   sec  5.60 GBytes  47.9 Gbits/sec
    [  7]   5.01-6.00   sec  5.60 GBytes  48.3 Gbits/sec
    [  7]   6.00-7.00   sec  5.57 GBytes  47.8 Gbits/sec
    [  7]   7.00-8.00   sec  5.58 GBytes  47.9 Gbits/sec
    [  7]   8.00-9.00   sec  5.58 GBytes  48.1 Gbits/sec
    [  7]   9.00-10.00  sec  5.59 GBytes  47.9 Gbits/sec
    - - - - - - - - - - - - - - - - - - - - - - - - -
    [ ID] Interval           Transfer     Bitrate         Retr
    [  7]   0.00-10.00  sec  55.9 GBytes  48.0 Gbits/sec    0            sender
    [  7]   0.00-10.00  sec  55.9 GBytes  48.0 Gbits/sec                  receiver

Podman vms tests show similar performance. No significant change
compared to fedora 43, so we don't update the plots.