### PR TITLE
Add network stats for debugging performance

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -78,6 +78,7 @@ jobs:
           sudo --preserve-env HOME=$HOME .venv/bin/python3 ./run test \
               --driver ${{ matrix.driver }} \
               --connection ${{ matrix.connection }} \
+              --stats-interval 1 \
               --timeout 300 \
               --verbose &
           pid=$!

--- a/docs/development.md
+++ b/docs/development.md
@@ -173,6 +173,41 @@ for debugging relative to the VM storage directory `~/.vmnet-helper/$VM`:
 └── vmnet-helper.log
 ```
 
+## `stats`: analyze vmnet-helper stats
+
+The `stats` script parses vmnet-helper logs and computes per-interval
+deltas for network counters. It requires the helper to be started with
+`--stats-interval SECONDS`.
+
+Start a VM with stats enabled:
+
+```console
+% ./run test --stats-interval 1
+```
+
+Show human-readable stats (transfer, bitrate, packets, drops):
+
+```console
+% ./stats ~/.vmnet-helper/vms/test/vmnet-helper.log
+- time: 2026-07-25T01:27:25.664+03:00
+  host:
+    transfer: 26.25 GBytes
+    bitrate: 21.00 Gbits/sec
+    packets: 69383 pkt/sec
+    drops: 0
+  vm:
+    transfer: 20.81 GBytes
+    bitrate: 16.65 Gbits/sec
+    packets: 52335 pkt/sec
+    drops: 0
+```
+
+Show raw JSON deltas for programmatic processing:
+
+```console
+% ./stats -o json ~/.vmnet-helper/vms/test/vmnet-helper.log | jq .
+```
+
 ### Limitations
 
 The `qemu` driver is not compatible with `--connection` set to `socket`.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -345,6 +345,24 @@ signal and wait until child process terminates.
 The vmnet helper logs to stderr. You can read the logs and integrate
 them in your application logs or redirect them to a file.
 
+## Debugging performance
+
+The **--stats-interval SECONDS** option enables periodic logging of
+network counters (packets, bytes, drops) to stderr as JSON. This is
+useful for debugging performance issues without enabling verbose
+logging, which makes the helper about 2x slower.
+
+```console
+% $(brew --prefix vmnet-helper)/libexec/vmnet-helper \
+    --fd 3 \
+    --stats-interval 1
+```
+
+The stats are cumulative counters logged at each interval. Programs
+integrating vmnet-helper can expose this option to their users (e.g.
+`--vmnet-stats-interval`) to allow debugging on end-user machines
+without rebuilding or restarting with verbose logging.
+
 [native-vmnet]: /docs/architecture.md#native-vmnet-on-macos-26
 [socket_vmnet]: https://github.com/lima-vm/socket_vmnet
 [vmnet-broker]: https://github.com/nirs/vmnet-broker

--- a/programs/helper.c
+++ b/programs/helper.c
@@ -8,6 +8,7 @@
 #include <pthread.h>
 #include <signal.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -35,7 +36,9 @@
 // Tesiting with iperf3 shows that there is no reason to use more than 128.
 #define MAX_PACKET_COUNT 128
 
-#define MICROSECOND 1000
+// Durations in nanoseconds.
+#define MICROSECOND 1000ULL
+#define MILLISECOND 1000000ULL
 
 // Testing show that one retry in enough in 72% of cases.  The following stats
 // are from 300 seconds iperf3 run at 7.85 Gbits/sec rate (679 kps).
@@ -54,6 +57,7 @@
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
 static const uintptr_t SHUTDOWN_EVENT = 1;
+static const uintptr_t STATS_TIMER = 2;
 
 enum {
     STATUS_FAILURE = 1,
@@ -68,6 +72,12 @@ struct network {
     uint8_t prefix_len;
 };
 
+struct forward_stats {
+    uint64_t packets;   // packets forwarded
+    uint64_t bytes;     // bytes forwarded
+    uint64_t drops;     // packets dropped
+};
+
 struct endpoint {
     dispatch_queue_t queue;
     struct vmpktdesc *packets;
@@ -76,6 +86,7 @@ struct endpoint {
     unsigned char *buffers;
     int max_packet_count;
     const char *name;
+    struct forward_stats stats;
 };
 
 static inline const char *bool_str(bool b)
@@ -826,13 +837,16 @@ static inline void wait_for_buffer_space(void)
     nanosleep(&t, NULL);
 }
 
+// TODO: Refactor - this function is too long and the fast-path/slow-path
+// fallthrough with shared state is hard to review.
 static void write_to_vm(int count)
 {
     for (int i = 0; i < count; i++) {
         host.msgs[i].msg_len = host.packets[i].vm_pkt_size;
     }
 
-    int sent = 0;
+    int packets = 0;
+    size_t bytes = 0;
 
     // Fast path.
 
@@ -840,7 +854,7 @@ static void write_to_vm(int count)
         uint64_t retries = 0;
 
         while (1) {
-            ssize_t n = sendmsg_x(options.fd, &host.msgs[sent], count-sent, 0);
+            ssize_t n = sendmsg_x(options.fd, &host.msgs[packets], count-packets, 0);
             if (n == -1) {
                 if (errno == ENOBUFS) {
                     wait_for_buffer_space();
@@ -849,13 +863,18 @@ static void write_to_vm(int count)
                 }
 
                 ERRORF("[host->vm] sendmsg_x: %s", strerror(errno));
+                bytes = host_packets_size(packets);
                 break;
             }
 
-            sent += n;
-            if (sent == count) {
+            packets += n;
+            if (packets == count) {
+                bytes = host_packets_size(packets);
+                host.stats.packets += packets;
+                host.stats.bytes += bytes;
+
                 DEBUGF("[host->vm] forwarded %d packets %zu bytes %lld retries",
-                        count, host_packets_size(count), retries);
+                        packets, bytes, retries);
                 return;
             }
         }
@@ -863,10 +882,9 @@ static void write_to_vm(int count)
 
     // Slow path.
 
-    size_t size = host_packets_size(sent);
-    int dropped = 0;
+    int drops = 0;
 
-    for (int i = sent; i < count; i++) {
+    for (int i = packets; i < count; i++) {
         struct vmpktdesc *packet = &host.packets[i];
         ssize_t len;
         uint64_t retries = 0;
@@ -885,12 +903,12 @@ static void write_to_vm(int count)
         if (len < 0) {
             // TODO: like socket_vmnet we drop the packet and continue. Maybe trigger shutdown?
             ERRORF("[host->vm] write: %s", strerror(errno));
-            dropped++;
+            drops++;
             continue;
         }
 
-        sent++;
-        size += packet->vm_pkt_size;
+        packets++;
+        bytes += packet->vm_pkt_size;
         if (retries > 0) {
             DEBUGF("[host->vm] write completed after %lld retries", retries);
         }
@@ -899,8 +917,12 @@ static void write_to_vm(int count)
         assert((size_t)len == packet->vm_pkt_size);
     }
 
-    DEBUGF("[host->vm] forwarded %d packets %zu bytes %d dropped",
-            sent, size, dropped);
+    host.stats.packets += packets;
+    host.stats.bytes += bytes;
+    host.stats.drops += drops;
+
+    DEBUGF("[host->vm] forwarded %d packets %zu bytes %d drops",
+            packets, bytes, drops);
 }
 
 static void packets_available(xpc_object_t event)
@@ -1013,8 +1035,11 @@ static void forward_from_vm(void)
             break;
         }
 
-        DEBUGF("[vm->host] forwarded %d packets %zu bytes",
-                count, vm_msgs_size(count));
+        size_t bytes = vm_msgs_size(count);
+        vm.stats.packets += count;
+        vm.stats.bytes += bytes;
+
+        DEBUGF("[vm->host] forwarded %d packets %zu bytes", count, bytes);
     }
 
     INFO("[vm->host] stopped");
@@ -1031,9 +1056,77 @@ static void start_forwarding_from_vm(void)
     INFO("[main] started vm forwarding");
 }
 
-static void wait_for_termination(void)
+static void iso_8601_timestamp(char *buf, size_t len)
 {
-    INFO("[main] waiting for termination");
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+
+    struct tm tm;
+    localtime_r(&ts.tv_sec, &tm);
+
+    char date[24];
+    size_t r = strftime(date, sizeof(date), "%Y-%m-%dT%H:%M:%S", &tm);
+    assert(r > 0);
+
+    int milliseconds = ts.tv_nsec / MILLISECOND;
+    int tz_hours = (int)(tm.tm_gmtoff / 3600);
+    int tz_minutes = abs((int)(tm.tm_gmtoff % 3600)) / 60;
+
+    int n = snprintf(buf, len, "%s.%03d%+03d:%02d", date, milliseconds,
+                     tz_hours, tz_minutes);
+    assert((size_t)n < len);
+}
+
+static void report_stats(void) {
+    char timestamp[32];
+    iso_8601_timestamp(timestamp, sizeof(timestamp));
+
+    INFOF("[stats] {"
+            "\"time\": \"%s\", "
+            "\"host\": {"
+                "\"packets\": %llu, "
+                "\"bytes\": %llu, "
+                "\"drops\": %llu"
+            "}, "
+            "\"vm\": {"
+                "\"packets\": %llu, "
+                "\"bytes\": %llu, "
+                "\"drops\": %llu"
+            "}"
+        "}",
+        timestamp,
+        host.stats.packets,
+        host.stats.bytes,
+        host.stats.drops,
+        vm.stats.packets,
+        vm.stats.bytes,
+        vm.stats.drops);
+}
+
+static void start_stats_timer(void) {
+    if (options.stats_interval == 0) {
+        return;
+    }
+
+    struct kevent change = {
+        .ident = STATS_TIMER,
+        .filter = EVFILT_TIMER,
+        .flags = EV_ADD,
+        .fflags = NOTE_SECONDS,
+        .data = options.stats_interval,
+    };
+
+    if (kevent(kq, &change, 1, NULL, 0, NULL) != 0) {
+        ERRORF("[main] kevent: %s", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    INFOF("[main] reporting stats every %d seconds", options.stats_interval);
+}
+
+static void run_until_termination(void)
+{
+    INFO("[main] running");
 
     struct kevent events[1];
 
@@ -1054,6 +1147,9 @@ static void wait_for_termination(void)
                 INFO("[main] received shutdown event");
                 status |= events[0].fflags;
                 break;
+            }
+            if (events[0].filter == EVFILT_TIMER) {
+                report_stats();
             }
         }
     }
@@ -1090,7 +1186,8 @@ int main(int argc, char **argv)
     setup_endpoints();
     start_forwarding_from_host();
     start_forwarding_from_vm();
-    wait_for_termination();
+    start_stats_timer();
+    run_until_termination();
 
     return (status == 0 || status & STATUS_STOPPED) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/programs/options.c
+++ b/programs/options.c
@@ -32,6 +32,7 @@ static void usage(int code)
 "                 [--start-address ADDR] [--end-address ADDR] [--subnet-mask MASK]\n"
 "                 [--enable-tso] [--enable-checksum-offload] [--enable-isolation]\n"
 "                 [--network NAME] [--list-shared-interfaces]\n"
+"                 [--stats-interval SECONDS]\n"
 "                 [-v|--verbose] [--version] [-h|--help]\n"
 "\n"
 "Modes:\n"
@@ -58,6 +59,7 @@ enum {
     OPT_ENABLE_ISOLATION,
     OPT_LIST_SHARED_INTERFACES,
     OPT_NETWORK,
+    OPT_STATS_INTERVAL,
     OPT_VERSION,
 };
 
@@ -77,6 +79,7 @@ static struct option long_options[] = {
     {"enable-isolation",        no_argument,        0,  OPT_ENABLE_ISOLATION},
     {"list-shared-interfaces",  no_argument,        0,  OPT_LIST_SHARED_INTERFACES},
     {"network",                 required_argument,  0,  OPT_NETWORK},
+    {"stats-interval",          required_argument,  0,  OPT_STATS_INTERVAL},
     {"verbose",                 no_argument,        0,  'v'},
     {"version",                 no_argument,        0,  OPT_VERSION},
     {"help",                    no_argument,        0,  'h'},
@@ -129,6 +132,18 @@ static void parse_id(const char *arg, const char *name, unsigned int *id)
         usage(1);
     }
     *id = value;
+}
+
+static void parse_stats_interval(const char *arg, int *interval)
+{
+    char *end;
+    errno = 0;
+    long value = strtol(arg, &end, 10);
+    if (errno != 0 || *end != 0 || value < 1 || value > INT_MAX) {
+        ERRORF("Invalid --stats value '%s': must be a positive integer", arg);
+        exit(EXIT_FAILURE);
+    }
+    *interval = value;
 }
 
 static void parse_interface_id(const char *arg, uuid_t uuid)
@@ -248,6 +263,9 @@ void parse_options(struct options *opts, int argc, char **argv)
         case OPT_NETWORK:
             opts->network_name = optarg;
             break;
+        case OPT_STATS_INTERVAL:
+            parse_stats_interval(optarg, &opts->stats_interval);
+            break;
         case 'v':
             verbose = true;
             break;
@@ -343,5 +361,4 @@ void parse_options(struct options *opts, int argc, char **argv)
             opts->gid = getgid();
         }
     }
-
 }

--- a/programs/options.h
+++ b/programs/options.h
@@ -22,6 +22,7 @@ struct options {
     bool enable_checksum_offload;
     uid_t uid;
     gid_t gid;
+    int stats_interval;
 };
 
 void parse_options(struct options *opts, int argc, char **argv);

--- a/programs/run.c
+++ b/programs/run.c
@@ -29,6 +29,7 @@ struct client_options {
     char *subnet_mask;
     char *shared_interface;
     char *network_name;
+    char *stats_interval;
     bool enable_tso;
     bool enable_checksum_offload;
     bool enable_isolation;
@@ -69,6 +70,7 @@ enum {
     OPT_ENABLE_CHECKSUM_OFFLOAD,
     OPT_ENABLE_ISOLATION,
     OPT_NETWORK,
+    OPT_STATS_INTERVAL,
     OPT_VERSION
 };
 
@@ -86,6 +88,7 @@ static struct option long_options[] = {
     {"enable-checksum-offload", no_argument,        0,  OPT_ENABLE_CHECKSUM_OFFLOAD},
     {"enable-isolation",        no_argument,        0,  OPT_ENABLE_ISOLATION},
     {"network",                 required_argument,  0,  OPT_NETWORK},
+    {"stats-interval",          required_argument,  0,  OPT_STATS_INTERVAL},
     {"verbose",                 no_argument,        0,  'v'},
     // Client options.
     {"version",                 no_argument,        0,  OPT_VERSION},
@@ -104,6 +107,7 @@ static void usage(int code)
 "              [--subnet-mask MASK] [--shared-interface NAME]\n"
 "              [--enable-tso] [--enable-checksum-offload]\n"
 "              [--enable-isolation] [--network NAME]\n"
+"              [--stats-interval SECONDS]\n"
 "              [-v|--verbose] [--version] [-h|--help]\n"
 "              -- command ...\n"
 "\n"
@@ -212,6 +216,11 @@ static void build_helper_argv(void)
         append_helper_arg(options.network_name);
     }
 
+    if (options.stats_interval) {
+        append_helper_arg("--stats-interval");
+        append_helper_arg(options.stats_interval);
+    }
+
     if (verbose) {
         append_helper_arg("--verbose");
     }
@@ -313,6 +322,9 @@ static void parse_options(int argc, char **argv)
             break;
         case OPT_NETWORK:
             options.network_name = optarg;
+            break;
+        case OPT_STATS_INTERVAL:
+            options.stats_interval = optarg;
             break;
         case 'v':
             verbose = true;

--- a/run
+++ b/run
@@ -85,6 +85,12 @@ def main():
         metavar="NAME",
         help="Join a network managed by vmnet-broker (macOS 26 only)",
     )
+    p.add_argument(
+        "--stats-interval",
+        metavar="SECONDS",
+        type=int,
+        help="Log stats every SECONDS seconds",
+    )
 
     # VM arguments
 

--- a/stats
+++ b/stats
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Compute per-interval stats from vmnet-helper logs.
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+
+import testing
+
+COUNTER_FIELDS = ["packets", "bytes", "drops"]
+
+KiB = 1024
+MiB = 1024 * KiB
+GiB = 1024 * MiB
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logfile", help="vmnet-helper log file")
+    parser.add_argument(
+        "-o",
+        "--output",
+        choices=["yaml", "json"],
+        default="yaml",
+        help="output format (yaml, json)",
+    )
+    args = parser.parse_args()
+
+    prev = None
+
+    for curr in testing.helper.parse_stats(args.logfile):
+        # Skip the first sample since we need two samples to compute
+        # the interval duration for rate calculation.
+        if prev is not None:
+            if args.output == "json":
+                print_json(prev, curr)
+            else:
+                print_yaml(prev, curr)
+
+        prev = curr
+
+
+def print_json(prev, curr):
+    delta = {"time": curr["time"], **compute_delta(prev, curr)}
+    print(json.dumps(delta))
+
+
+def print_yaml(prev, curr):
+    t0 = datetime.fromisoformat(prev["time"])
+    t1 = datetime.fromisoformat(curr["time"])
+    duration = (t1 - t0).total_seconds()
+    if duration <= 0:
+        return
+
+    delta = compute_delta(prev, curr)
+    print(f"- time: {curr['time']}")
+    for endpoint in ("host", "vm"):
+        d = delta[endpoint]
+        bps = d["bytes"] / duration
+        pps = int(d["packets"] / duration)
+        print(f"  {endpoint}:")
+        print(f"    transfer: {format_bytes(d['bytes'])}")
+        print(f"    bitrate: {format_bits_per_sec(bps)}")
+        print(f"    packets: {pps} pkt/sec")
+        print(f"    drops: {d['drops']}")
+
+
+def compute_delta(prev, curr):
+    delta = {}
+    for endpoint in ("host", "vm"):
+        delta[endpoint] = {
+            field: curr[endpoint][field] - prev[endpoint][field]
+            for field in COUNTER_FIELDS
+        }
+    return delta
+
+
+def format_bytes(n):
+    # Use 1024-based units with iperf3 labels (GBytes, not GiB).
+    if n >= GiB:
+        return f"{n / GiB:.2f} GBytes"
+    if n >= MiB:
+        return f"{n / MiB:.2f} MBytes"
+    if n >= KiB:
+        return f"{n / KiB:.2f} KBytes"
+    return f"{n} Bytes"
+
+
+def format_bits_per_sec(bps):
+    # Use 1000-based units following networking convention.
+    bits = bps * 8
+    if bits >= 1_000_000_000:
+        return f"{bits / 1_000_000_000:.2f} Gbits/sec"
+    if bits >= 1_000_000:
+        return f"{bits / 1_000_000:.2f} Mbits/sec"
+    if bits >= 1_000:
+        return f"{bits / 1_000:.2f} Kbits/sec"
+    return f"{bits:.0f} bits/sec"
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/helper.py
+++ b/testing/helper.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import platform
+import re
 import socket
 import subprocess
 import uuid
@@ -207,3 +208,17 @@ def shared_interfaces():
         check=True,
     )
     return cp.stdout.decode().splitlines()
+
+
+_STATS_RE = re.compile(r"\[stats\] (\{.*\})")
+
+
+def parse_stats(logfile):
+    """
+    Yield parsed stats entries from a vmnet-helper log file.
+    """
+    with open(logfile) as f:
+        for line in f:
+            m = _STATS_RE.search(line)
+            if m:
+                yield json.loads(m.group(1))

--- a/testing/helper.py
+++ b/testing/helper.py
@@ -62,6 +62,7 @@ class Helper:
         self.network_name = args.network_name
         self.enable_isolation = args.enable_isolation
         self.enable_offloading = args.enable_offloading
+        self.stats_interval = args.stats_interval
         self.verbose = args.verbose
         self.generate_interface_id = generate_interface_id
 
@@ -157,6 +158,9 @@ class Helper:
 
         if self.enable_offloading:
             cmd.extend(["--enable-tso", "--enable-checksum-offload"])
+
+        if self.stats_interval:
+            cmd.append(f"--stats-interval={self.stats_interval}")
 
         if self.verbose:
             cmd.append("--verbose")

--- a/testing/helper.py
+++ b/testing/helper.py
@@ -50,7 +50,9 @@ NET_IPV6_PREFIX_LEN = "net_ipv6_prefix_len"
 
 
 class Helper:
-    def __init__(self, args, fd=None, socket=None, generate_interface_id=True):
+    def __init__(
+        self, args, fd=None, socket=None, logfile=None, generate_interface_id=True
+    ):
         # Configuration
         self.fd = fd
         self.socket = socket
@@ -70,6 +72,7 @@ class Helper:
         # Running state.
         self.proc = None
         self.interface = None
+        self.logfile = logfile
 
     def start(self):
         """
@@ -90,11 +93,12 @@ class Helper:
             )
         cmd = self._build_command(interface_id)
 
-        vm_home = store.vm_path(self.vm_name)
-        os.makedirs(vm_home, exist_ok=True)
-        logfile = os.path.join(vm_home, "vmnet-helper.log")
+        if self.logfile is None:
+            vm_home = store.vm_path(self.vm_name)
+            os.makedirs(vm_home, exist_ok=True)
+            self.logfile = os.path.join(vm_home, "vmnet-helper.log")
 
-        with open(logfile, "w") as log:
+        with open(self.logfile, "w") as log:
             self.proc = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,

--- a/testing/helper_test.py
+++ b/testing/helper_test.py
@@ -24,6 +24,7 @@ import os
 import platform
 import socket
 import time
+from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
@@ -414,6 +415,53 @@ if MACOS_26:
             with run_helper(network_name="shared", tmp_path=tmp_path) as (h, sock):
                 gateway_mac = arp_resolve(h, sock)
                 retry(ping_any, h, sock, gateway_mac, external_ips)
+
+
+class TestStats:
+    """
+    Test stats reporting via --stats-interval.
+    """
+
+    def test_stats_logged(self, tmp_path):
+        """
+        Test that stats are logged in valid JSON format after sending traffic.
+        """
+        with run_helper(stats_interval=1, tmp_path=tmp_path) as (h, sock):
+            gateway_mac = arp_resolve(h, sock)
+            gateway_ip = find_gateway_ip(h.interface)
+            ping(h, sock, gateway_mac, gateway_ip)
+
+            # Wait for the stats timer to fire.
+            time.sleep(1.5)
+
+        stats = list(helper.parse_stats(h.logfile))
+        assert len(stats) > 0, "No stats found in log"
+        for s in stats:
+            log.debug("stats: %s", s)
+
+        entry = stats[0]
+        assert "time" in entry
+        datetime.fromisoformat(entry["time"])
+        for endpoint in ("host", "vm"):
+            for field in ("packets", "bytes", "drops"):
+                assert field in entry[endpoint]
+                assert isinstance(entry[endpoint][field], int)
+        assert entry["host"]["packets"] > 0
+        assert entry["host"]["bytes"] > 0
+
+    def test_no_stats_by_default(self, tmp_path):
+        """
+        Test that stats are not logged when --stats-interval is not set.
+        """
+        with run_helper(tmp_path=tmp_path) as (h, sock):
+            gateway_mac = arp_resolve(h, sock)
+            gateway_ip = find_gateway_ip(h.interface)
+            ping(h, sock, gateway_mac, gateway_ip)
+
+            time.sleep(1.5)
+
+        stats = list(helper.parse_stats(h.logfile))
+        assert len(stats) == 0, "Stats should not be logged by default"
 
 
 # --- Helper runner ---

--- a/testing/helper_test.py
+++ b/testing/helper_test.py
@@ -82,27 +82,28 @@ class TestStart:
     Test that vmnet-helper starts correctly with various options
     """
 
-    def test_default_mode(self):
+    def test_default_mode(self, tmp_path):
         """
         Test starting helper without mode default to "shared".
         """
-        with run_helper() as (h, sock):
+        with run_helper(tmp_path=tmp_path) as (h, sock):
             self.check_interface(h.interface)
             # If network options are unset, vmnet selects the next available network.
 
-    def test_shared_mode(self):
+    def test_shared_mode(self, tmp_path):
         """
         Test starting helper with shared mode
         """
-        with run_helper(operation_mode="shared") as (h, sock):
+        with run_helper(operation_mode="shared", tmp_path=tmp_path) as (h, sock):
             self.check_interface(h.interface)
             # If network options are unset, vmnet selects the next available network.
 
-    def test_shared_mode_specific_network_16(self):
+    def test_shared_mode_specific_network_16(self, tmp_path):
         """
         Test starting helper with 192.168.0.0/16 network (RFC 1918).
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="shared",
             start_address="192.168.200.1",
             end_address="192.168.200.254",
@@ -111,11 +112,12 @@ class TestStart:
             self.check_interface(h.interface)
             self.check_specific_network(h)
 
-    def test_shared_mode_specific_network_8(self):
+    def test_shared_mode_specific_network_8(self, tmp_path):
         """
         Test starting helper with 10.0.0.0/8 network (RFC 1918).
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="shared",
             start_address="10.200.0.1",
             end_address="10.200.0.254",
@@ -124,11 +126,12 @@ class TestStart:
             self.check_interface(h.interface)
             self.check_specific_network(h)
 
-    def test_shared_mode_specific_network_12(self):
+    def test_shared_mode_specific_network_12(self, tmp_path):
         """
         Test starting helper with 172.16.0.0/12 network (RFC 1918).
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="shared",
             start_address="172.16.200.1",
             end_address="172.16.200.254",
@@ -137,12 +140,13 @@ class TestStart:
             self.check_interface(h.interface)
             self.check_specific_network(h)
 
-    def test_shared_mode_specific_network_30(self):
+    def test_shared_mode_specific_network_30(self, tmp_path):
         """
         Test starting helper with /30 subnet (1 usable address).
         anylinuxfs uses this to isolate the VM from other VMs on the network.
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="shared",
             start_address="192.168.200.1",
             end_address="192.168.200.2",
@@ -151,11 +155,12 @@ class TestStart:
             self.check_interface(h.interface)
             self.check_specific_network(h)
 
-    def test_shared_mode_specific_network_30_last(self):
+    def test_shared_mode_specific_network_30_last(self, tmp_path):
         """
         Test starting helper with the last /30 subnet (1 usable address).
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="shared",
             start_address="192.168.200.253",
             end_address="192.168.200.254",
@@ -164,31 +169,34 @@ class TestStart:
             self.check_interface(h.interface)
             self.check_specific_network(h)
 
-    def test_shared_mode_isolated(self):
+    def test_shared_mode_isolated(self, tmp_path):
         """
         Test starting helper in shared mode with isolation
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="shared",
             enable_isolation=True,
         ) as (h, sock):
             self.check_interface(h.interface)
 
-    def test_host_mode(self):
+    def test_host_mode(self, tmp_path):
         """
         Test starting helper in host mode
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="host",
         ) as (h, sock):
             self.check_interface(h.interface)
             # If network options are unset, vmnet selects the next available network.
 
-    def test_host_mode_specific_network_16(self):
+    def test_host_mode_specific_network_16(self, tmp_path):
         """
         Test starting helper with 192.168.0.0/16 network (RFC 1918).
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="host",
             start_address="192.168.200.1",
             end_address="192.168.200.254",
@@ -197,11 +205,12 @@ class TestStart:
             self.check_interface(h.interface)
             self.check_specific_network(h)
 
-    def test_host_mode_specific_network_8(self):
+    def test_host_mode_specific_network_8(self, tmp_path):
         """
         Test starting helper with 10.0.0.0/8 network (RFC 1918).
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="host",
             start_address="10.200.0.1",
             end_address="10.200.0.254",
@@ -210,11 +219,12 @@ class TestStart:
             self.check_interface(h.interface)
             self.check_specific_network(h)
 
-    def test_host_mode_specific_network_12(self):
+    def test_host_mode_specific_network_12(self, tmp_path):
         """
         Test starting helper with 172.16.0.0/12 network (RFC 1918).
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="host",
             start_address="172.16.200.1",
             end_address="172.16.200.254",
@@ -223,11 +233,12 @@ class TestStart:
             self.check_interface(h.interface)
             self.check_specific_network(h)
 
-    def test_host_mode_specific_network_30(self):
+    def test_host_mode_specific_network_30(self, tmp_path):
         """
         Test starting helper with /30 subnet (1 usable address).
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="host",
             start_address="192.168.200.1",
             end_address="192.168.200.2",
@@ -236,11 +247,12 @@ class TestStart:
             self.check_interface(h.interface)
             self.check_specific_network(h)
 
-    def test_host_mode_specific_network_30_last(self):
+    def test_host_mode_specific_network_30_last(self, tmp_path):
         """
         Test starting helper with the last /30 subnet (1 usable address).
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="host",
             start_address="192.168.200.253",
             end_address="192.168.200.254",
@@ -249,22 +261,23 @@ class TestStart:
             self.check_interface(h.interface)
             self.check_specific_network(h)
 
-    def test_host_mode_isolated(self):
+    def test_host_mode_isolated(self, tmp_path):
         """
         Test starting helper in host mode with isolation
         """
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="host",
             enable_isolation=True,
         ) as (h, sock):
             self.check_interface(h.interface)
 
-    def test_no_interface_id(self):
+    def test_no_interface_id(self, tmp_path):
         """
         Test starting helper without --interface-id. vmnet should assign
         a new interface identifier and MAC address.
         """
-        with run_helper(generate_interface_id=False) as (h, sock):
+        with run_helper(tmp_path=tmp_path, generate_interface_id=False) as (h, sock):
             assert VMNET_INTERFACE_ID in h.interface
             assert VMNET_MAC_ADDRESS in h.interface
             assert VMNET_MAX_PACKET_SIZE in h.interface
@@ -289,33 +302,33 @@ class TestConnectivity:
     Test network connectivity using scapy
     """
 
-    def test_arp_gateway(self):
+    def test_arp_gateway(self, tmp_path):
         """
         Test ARP resolution to gateway
         """
-        with run_helper(operation_mode="shared") as (h, sock):
+        with run_helper(operation_mode="shared", tmp_path=tmp_path) as (h, sock):
             gateway_mac = arp_resolve(h, sock)
             assert gateway_mac is not None
 
-    def test_ping_gateway(self):
+    def test_ping_gateway(self, tmp_path):
         """
         Test ICMP ping to gateway
         """
-        with run_helper(operation_mode="shared") as (h, sock):
+        with run_helper(operation_mode="shared", tmp_path=tmp_path) as (h, sock):
             gateway_mac = arp_resolve(h, sock)
             gateway_ip = find_gateway_ip(h.interface)
             ping(h, sock, gateway_mac, gateway_ip)
 
-    def test_ping_external_via_nat(self):
+    def test_ping_external_via_nat(self, tmp_path):
         """
         Test ICMP ping to external IP via NAT
         """
         external_ips = ["1.1.1.1", "8.8.8.8"]
-        with run_helper(operation_mode="shared") as (h, sock):
+        with run_helper(operation_mode="shared", tmp_path=tmp_path) as (h, sock):
             gateway_mac = arp_resolve(h, sock)
             retry(ping_any, h, sock, gateway_mac, external_ips)
 
-    def test_partial_dhcp_range(self):
+    def test_partial_dhcp_range(self, tmp_path):
         """
         Test that vmnet accepts a DHCP range smaller than the full subnet,
         and that both gateway and NAT traffic work. This allows reserving
@@ -323,6 +336,7 @@ class TestConnectivity:
         """
         external_ips = ["1.1.1.1", "8.8.8.8"]
         with run_helper(
+            tmp_path=tmp_path,
             operation_mode="shared",
             start_address="192.168.200.1",
             end_address="192.168.200.200",
@@ -344,18 +358,18 @@ if MACOS_26:
         Test starting helper with --network option (macOS 26 only)
         """
 
-        def test_shared_network(self):
+        def test_shared_network(self, tmp_path):
             """
             Test starting helper with shared network
             """
-            with run_helper(network_name="shared") as (h, sock):
+            with run_helper(network_name="shared", tmp_path=tmp_path) as (h, sock):
                 self.check_interface(h.interface)
 
-        def test_host_network(self):
+        def test_host_network(self, tmp_path):
             """
             Test starting helper with host network
             """
-            with run_helper(network_name="host") as (h, sock):
+            with run_helper(network_name="host", tmp_path=tmp_path) as (h, sock):
                 self.check_interface(h.interface)
 
         def check_interface(self, interface):
@@ -375,29 +389,29 @@ if MACOS_26:
         Test network connectivity with --network option (macOS 26 only)
         """
 
-        def test_arp_gateway(self):
+        def test_arp_gateway(self, tmp_path):
             """
             Test ARP resolution to gateway
             """
-            with run_helper(network_name="shared") as (h, sock):
+            with run_helper(network_name="shared", tmp_path=tmp_path) as (h, sock):
                 gateway_mac = arp_resolve(h, sock)
                 assert gateway_mac is not None
 
-        def test_ping_gateway(self):
+        def test_ping_gateway(self, tmp_path):
             """
             Test ICMP ping to gateway
             """
-            with run_helper(network_name="shared") as (h, sock):
+            with run_helper(network_name="shared", tmp_path=tmp_path) as (h, sock):
                 gateway_mac = arp_resolve(h, sock)
                 gateway_ip = find_gateway_ip(h.interface)
                 ping(h, sock, gateway_mac, gateway_ip)
 
-        def test_ping_external_via_nat(self):
+        def test_ping_external_via_nat(self, tmp_path):
             """
             Test ICMP ping to external IP via NAT
             """
             external_ips = ["1.1.1.1", "8.8.8.8"]
-            with run_helper(network_name="shared") as (h, sock):
+            with run_helper(network_name="shared", tmp_path=tmp_path) as (h, sock):
                 gateway_mac = arp_resolve(h, sock)
                 retry(ping_any, h, sock, gateway_mac, external_ips)
 
@@ -417,6 +431,7 @@ def run_helper(
     enable_isolation=False,
     enable_offloading=False,
     stats_interval=None,
+    tmp_path=None,
     generate_interface_id=True,
     verbose=True,
 ):
@@ -446,11 +461,14 @@ def run_helper(
         verbose=verbose,
     )
 
+    logfile = str(tmp_path / "vmnet-helper.log") if tmp_path else None
+
     host_sock, vm_sock = helper.socketpair()
     try:
         h = helper.Helper(
             args,
             fd=vm_sock.fileno(),
+            logfile=logfile,
             generate_interface_id=generate_interface_id,
         )
         h.start()

--- a/testing/helper_test.py
+++ b/testing/helper_test.py
@@ -416,6 +416,7 @@ def run_helper(
     network_name=None,
     enable_isolation=False,
     enable_offloading=False,
+    stats_interval=None,
     generate_interface_id=True,
     verbose=True,
 ):
@@ -441,6 +442,7 @@ def run_helper(
         network_name=network_name,
         enable_isolation=enable_isolation,
         enable_offloading=enable_offloading,
+        stats_interval=stats_interval,
         verbose=verbose,
     )
 

--- a/testing/vm.py
+++ b/testing/vm.py
@@ -289,6 +289,8 @@ class VM:
             cmd.append(f"--shared-interface={self.args.shared_interface}")
         if self.enable_offloading:
             cmd.extend(["--enable-tso", "--enable-checksum-offload"])
+        if self.args.stats_interval:
+            cmd.append(f"--stats-interval={self.args.stats_interval}")
         if self.verbose:
             cmd.append("--verbose")
         cmd.append("--")


### PR DESCRIPTION
Add per-thread network counters (packets, bytes, drops) to
vmnet-helper, reported periodically via a kqueue timer. Enabled with
`--stats-interval SECONDS`, disabled by default.

This allows debugging performance issues without verbose logging,
which makes the helper about 2x slower. The counters match Linux
network device stats and are safe to read without locking on 64-bit
machines.

The stats are logged as JSON to stderr and can be analyzed with the
included `stats` script, which computes per-interval deltas and
formats output with adaptive units matching iperf3 conventions.

Next steps: add ENOBUFS and retry counters, which are currently only
visible in debug logs.