### PR TITLE
Replace macos-15-intel with macos-26-intel

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -33,15 +33,14 @@ jobs:
         include:
           - os: macos-26
             method: brew
+            vmnet_helper: /opt/homebrew/opt/vmnet-helper/libexec/vmnet-helper
           - os: macos-15
             method: install.sh
+            vmnet_helper: /opt/vmnet-helper/bin/vmnet-helper
           - os: macos-14
             method: install.sh
+            vmnet_helper: /opt/vmnet-helper/bin/vmnet-helper
     runs-on: ${{ matrix.os }}
-    env:
-      # Homebrew installs to libexec, install script to /opt
-      VMNET_HELPER_BREW: /opt/homebrew/opt/vmnet-helper/libexec/vmnet-helper
-      VMNET_HELPER_INSTALL_SH: /opt/vmnet-helper/bin/vmnet-helper
     steps:
       - name: Host info
         run: |
@@ -90,12 +89,7 @@ jobs:
           EXPECTED_VERSION: ${{ steps.release.outputs.version }}
           EXPECTED_COMMIT: ${{ steps.release.outputs.commit }}
         run: |
-          if [[ "${{ matrix.method }}" == "brew" ]]; then
-            vmnet_helper="$VMNET_HELPER_BREW"
-          else
-            vmnet_helper="$VMNET_HELPER_INSTALL_SH"
-          fi
-
+          vmnet_helper="${{ matrix.vmnet_helper }}"
           echo "Checking $vmnet_helper"
           output=$("$vmnet_helper" --version)
           echo "$output"

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -34,6 +34,9 @@ jobs:
           - os: macos-26
             method: brew
             vmnet_helper: /opt/homebrew/opt/vmnet-helper/libexec/vmnet-helper
+          - os: macos-26-intel
+            method: brew
+            vmnet_helper: /usr/local/opt/vmnet-helper/libexec/vmnet-helper
           - os: macos-15
             method: install.sh
             vmnet_helper: /opt/vmnet-helper/bin/vmnet-helper

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -13,9 +13,9 @@ permissions:
 jobs:
   example:
     name: Example
-    # macos-26 (arm64) is using M1 cpu but nested virtualization require M3 or
-    # later.
-    runs-on: macos-15-intel
+    # macos-26 (arm64) uses M1 cpu but nested virtualization requires M3 or
+    # later. macos-26-intel supports nested virtualization.
+    runs-on: macos-26-intel
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15, macos-15-intel, macos-26]
+        os: [macos-14, macos-15, macos-26-intel, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Host info
@@ -62,7 +62,7 @@ jobs:
       - name: Install vmnet-helper
         run: VMNET_INTERACTIVE=0 ./install.sh build/vmnet-helper.tar.gz
       - name: Install vmnet-broker
-        if: matrix.os == 'macos-26'
+        if: startsWith(matrix.os, 'macos-26')
         run: curl -fsSL https://github.com/nirs/vmnet-broker/releases/latest/download/install.sh | sudo bash
       - name: Create virtual env
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 
 # Editor files
 /.zed/
-/pyrightconfig.json
 
 # Python
 __pycache__

--- a/programs/helper.c
+++ b/programs/helper.c
@@ -779,10 +779,9 @@ static void setup_socket(void)
     wait_for_client();
     connect_socket();
 
-    // Once a client connected, we cannot serve any other client, so it would
-    // be nice to remove the socket now. This breaks krunkit since libkrun does
-    // not connect to the socket and use sendto().
-    // https://github.com/containers/libkrun/blob/57a5a6bfbe5d2333d88fd88fcedb9c1d1fec9cc2/src/devices/src/virtio/net/gvproxy.rs#L113
+    // TODO: Once a client connected, we cannot serve any other client, so we
+    // should remove the socket now. This was fixed in libkrun PR #263.
+    // https://github.com/libkrun/libkrun/pull/263
 }
 
 static void setup_endpoints(void)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+    "venvPath": ".",
+    "venv": ".venv"
+}

--- a/testing/cidata.py
+++ b/testing/cidata.py
@@ -5,12 +5,12 @@ import ipaddress
 import glob
 import logging
 import os
-import subprocess
 import uuid
 import tempfile
 
 import yaml
 
+from . import privileges
 from . import process
 from . import store
 
@@ -104,6 +104,11 @@ def create_iso(vm):
         with open(network_config_path, "w") as f:
             yaml.dump(network_config, f, sort_keys=False)
 
+        uid, gid = privileges.creds()
+        if uid and gid:
+            for path in tmp, meta_data_path, user_data_path, network_config_path:
+                os.chown(path, uid, gid)
+
         cmd = [
             "mkisofs",
             "-output",
@@ -118,8 +123,8 @@ def create_iso(vm):
         ]
         process.run(
             *cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=process.PIPE,
+            stderr=process.PIPE,
             cwd=tmp,
             check=True,
         )
@@ -204,7 +209,7 @@ def file_matches(data, iso_path, file_path):
         iso_path,
         "--to-stdout",
         file_path,
-        stdout=subprocess.PIPE,
+        stdout=process.PIPE,
         check=True,
     )
     file_data = yaml.safe_load(extract.stdout)

--- a/testing/cidata.py
+++ b/testing/cidata.py
@@ -11,6 +11,7 @@ import tempfile
 
 import yaml
 
+from . import process
 from . import store
 
 # Enable busy polling for network sockets to reduce softirq overhead.
@@ -115,12 +116,12 @@ def create_iso(vm):
             "meta-data",
             "network-config",
         ]
-        subprocess.run(
-            cmd,
-            check=True,
+        process.run(
+            *cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=tmp,
+            check=True,
         )
 
     return cidata
@@ -197,10 +198,14 @@ def file_matches(data, iso_path, file_path):
 
     Returns True if they match, False otherwise.
     """
-    extract = subprocess.run(
-        ["bsdtar", "-xf", iso_path, "--to-stdout", file_path],
-        check=True,
+    extract = process.run(
+        "bsdtar",
+        "-xf",
+        iso_path,
+        "--to-stdout",
+        file_path,
         stdout=subprocess.PIPE,
+        check=True,
     )
     file_data = yaml.safe_load(extract.stdout)
     return data == file_data

--- a/testing/disks.py
+++ b/testing/disks.py
@@ -85,8 +85,7 @@ def create_image(url, format=None, size=None):
     url_hash = hashlib.sha256(url.encode()).hexdigest()
     path = store.cache_path("images", url_hash, "data")
     if not os.path.exists(path):
-        image_dir = os.path.dirname(path)
-        os.makedirs(image_dir, exist_ok=True)
+        store.ensure_cache_dir("images", url_hash)
         tmp_path = path + ".tmp"
         try:
             download_image(url, tmp_path)

--- a/testing/disks.py
+++ b/testing/disks.py
@@ -5,8 +5,8 @@ import hashlib
 import logging
 import os
 import platform
-import subprocess
 
+from . import process
 from . import store
 
 UBUNTU_RELEASE = "26.04"
@@ -106,7 +106,7 @@ def create_image(url, format=None, size=None):
 
 def download_image(image_url, path):
     logging.info("Downloading image '%s'", image_url)
-    cmd = [
+    process.run(
         "curl",
         "--fail",
         "--no-progress-meter",
@@ -114,21 +114,19 @@ def download_image(image_url, path):
         "--output",
         path,
         image_url,
-    ]
-    subprocess.run(cmd, check=True)
+    )
 
 
 def convert_image(src, target, format):
     logging.info("Converting image to '%s' format '%s'", format, target)
-    cmd = ["qemu-img", "convert", "-f", "qcow2", "-O", format, src, target]
-    subprocess.run(cmd, check=True)
+    process.run("qemu-img", "convert", "-f", "qcow2", "-O", format, src, target)
 
 
 def resize_image(path, size):
     logging.info("Resizing image to %s", size)
-    cmd = ["qemu-img", "resize", "-q", "-f", "raw", path, size]
-    subprocess.run(cmd, check=True)
+    process.run("qemu-img", "resize", "-q", "-f", "raw", path, size)
 
 
 def clone(src, dst):
-    subprocess.run(["cp", "-c", src, dst], check=True)
+    logging.info("Cloning image %s to %s", src, dst)
+    process.run("cp", "-c", src, dst)

--- a/testing/helper.py
+++ b/testing/helper.py
@@ -11,8 +11,9 @@ import socket
 import uuid
 
 from . import mac
-from . import store
+from . import privileges
 from . import process
+from . import store
 
 PREFIX = "/opt/vmnet-helper"
 HELPER = os.path.join(PREFIX, "bin/vmnet-helper")
@@ -98,11 +99,13 @@ class Helper:
         cmd = self._build_command(interface_id)
 
         if self.logfile is None:
-            vm_home = store.vm_path(self.vm_name)
-            os.makedirs(vm_home, exist_ok=True)
+            vm_home = store.ensure_vm_dir(self.vm_name)
             self.logfile = os.path.join(vm_home, "vmnet-helper.log")
 
+        uid, gid = privileges.creds()
         with open(self.logfile, "w") as log:
+            if uid and gid:
+                os.chown(self.logfile, uid, gid)
             self.proc = process.start(
                 *cmd,
                 stdout=process.PIPE,

--- a/testing/helper.py
+++ b/testing/helper.py
@@ -8,11 +8,11 @@ import os
 import platform
 import re
 import socket
-import subprocess
 import uuid
 
 from . import mac
 from . import store
+from . import process
 
 PREFIX = "/opt/vmnet-helper"
 HELPER = os.path.join(PREFIX, "bin/vmnet-helper")
@@ -103,9 +103,9 @@ class Helper:
             self.logfile = os.path.join(vm_home, "vmnet-helper.log")
 
         with open(self.logfile, "w") as log:
-            self.proc = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
+            self.proc = process.start(
+                *cmd,
+                stdout=process.PIPE,
                 stderr=log,
                 pass_fds=[self.fd] if self.fd is not None else [],
             )
@@ -215,9 +215,9 @@ def socketpair(offloading=False):
 
 
 def shared_interfaces():
-    cp = subprocess.run(
-        ["/opt/vmnet-helper/bin/vmnet-helper", "--list-shared-interfaces"],
-        stdout=subprocess.PIPE,
-        check=True,
+    cp = process.run(
+        "/opt/vmnet-helper/bin/vmnet-helper",
+        "--list-shared-interfaces",
+        stdout=process.PIPE,
     )
     return cp.stdout.decode().splitlines()

--- a/testing/helper.py
+++ b/testing/helper.py
@@ -177,8 +177,10 @@ class Helper:
         return cmd
 
     def stop(self):
-        self.proc.terminate()
-        self.proc.wait()
+        if self.proc:
+            self.proc.terminate()
+            self.proc.wait()
+            self.proc = None
 
 
 def requires_root():

--- a/testing/privileges.py
+++ b/testing/privileges.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+
+def creds():
+    """
+    Return (user, group) for dropping privileges when running as root.
+
+    When the test runs as root (e.g. via sudo for mDNS access in CI),
+    the VM command must run as the unprivileged user so its files and
+    sockets are accessible by vmnet-helper after it drops privileges.
+
+    Uses SUDO_UID/SUDO_GID like vmnet-helper does. Returns (None, None)
+    when not running as root.
+    """
+    if os.geteuid() != 0:
+        return None, None
+
+    sudo_uid = os.environ.get("SUDO_UID")
+    uid = int(sudo_uid) if sudo_uid else os.getuid()
+
+    # Running as root directly (not via sudo) — no unprivileged user to drop to.
+    if uid == 0:
+        return None, None
+
+    sudo_gid = os.environ.get("SUDO_GID")
+    gid = int(sudo_gid) if sudo_gid else os.getgid()
+
+    return uid, gid

--- a/testing/process.py
+++ b/testing/process.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+
+# Avoid importing subprocess in callers.
+from subprocess import PIPE
+
+
+def run(*args, stdout=None, stderr=None, cwd=None, check=True):
+    """
+    Runs a command as unprivilegd user, waits for it to complete, then returns a
+    CompletedProcess instance.
+    """
+    return subprocess.run(
+        args,
+        stdout=stdout,
+        stderr=stderr,
+        cwd=cwd,
+        check=check,
+    )
+
+
+def start(*args, stdout=None, stderr=None, pass_fds=()):
+    """
+    Starts a new process as unprivileged user. Return subprocess.Popen()
+    instance for waiting and terminating the new process.
+    """
+    return subprocess.Popen(
+        args,
+        stdout=stdout,
+        stderr=stderr,
+        pass_fds=pass_fds,
+    )

--- a/testing/process.py
+++ b/testing/process.py
@@ -6,18 +6,23 @@ import subprocess
 # Avoid importing subprocess in callers.
 from subprocess import PIPE
 
+from . import privileges
+
 
 def run(*args, stdout=None, stderr=None, cwd=None, check=True):
     """
     Runs a command as unprivilegd user, waits for it to complete, then returns a
     CompletedProcess instance.
     """
+    uid, gid = privileges.creds()
     return subprocess.run(
         args,
         stdout=stdout,
         stderr=stderr,
         cwd=cwd,
         check=check,
+        user=uid,
+        group=gid,
     )
 
 
@@ -26,9 +31,12 @@ def start(*args, stdout=None, stderr=None, pass_fds=()):
     Starts a new process as unprivileged user. Return subprocess.Popen()
     instance for waiting and terminating the new process.
     """
+    uid, gid = privileges.creds()
     return subprocess.Popen(
         args,
         stdout=stdout,
         stderr=stderr,
         pass_fds=pass_fds,
+        user=uid,
+        group=gid,
     )

--- a/testing/ssh.py
+++ b/testing/ssh.py
@@ -4,6 +4,7 @@
 import logging
 import os
 
+from . import privileges
 from . import store
 
 
@@ -27,3 +28,6 @@ Host {vm.vm_name}
     logging.info("Creating ssh config '%s'", path)
     with open(path, "w") as f:
         f.write(data)
+    uid, gid = privileges.creds()
+    if uid and gid:
+        os.chown(path, uid, gid)

--- a/testing/store.py
+++ b/testing/store.py
@@ -3,21 +3,63 @@
 
 import os
 
-HOME = os.path.expanduser("~/.vmnet-helper")
+from . import privileges
+
+HOME = os.path.expanduser("~")
+BASE = os.path.join(HOME, ".vmnet-helper")
 
 
 def vm_path(*parts):
     """
     Build path for vm files.
     """
-    return os.path.join(HOME, "vms", *parts)
+    return os.path.join(BASE, "vms", *parts)
 
 
 def cache_path(*parts):
     """
     Build path for cached files.
     """
-    return os.path.join(HOME, "cache", *parts)
+    return os.path.join(BASE, "cache", *parts)
+
+
+def ensure_vm_dir(*parts):
+    """
+    Ensure that vm directory exists.
+    """
+    return _ensure_directory(BASE, "vms", *parts)
+
+
+def ensure_cache_dir(*parts):
+    """
+    Ensure that cache directory exists.
+    """
+    return _ensure_directory(BASE, "cache", *parts)
+
+
+def _ensure_directory(*parts):
+    """
+    Ensures directory and all intermediate directories from HOME exist with
+    specified mode and owned by unprivileged user and group. Returns the
+    directory path.
+
+    When running in CI as root, we want to create directories owned by SUDO_USER
+    and SUDO_GROUP so we can run the vm and helper as unprivileged user.  We
+    cannot use os.makedirs() since it does not change ownership.
+    """
+    mode = 0o700
+    uid, gid = privileges.creds()
+    path = HOME  # HOME exists and have right owner.
+    for part in parts:
+        path = os.path.join(path, part)
+        try:
+            os.mkdir(path, mode=mode)
+        except FileExistsError:
+            pass  # Should have right owner.
+        else:
+            if uid and gid:
+                os.chown(path, uid, gid)
+    return path
 
 
 def silent_remove(path):

--- a/testing/vm.py
+++ b/testing/vm.py
@@ -99,8 +99,10 @@ class VM:
             )
 
     def stop(self):
-        self.proc.terminate()
-        self.proc.wait()
+        if self.proc:
+            self.proc.terminate()
+            self.proc.wait()
+            self.proc = None
 
     def write_command(self, cmd):
         """
@@ -153,12 +155,14 @@ class VM:
         logging.warning("Timeout waiting for vm to become reachable")
 
     def check_running(self):
-        if self.proc.poll() is not None:
-            raise RuntimeError(
-                f"Virtual machine terminated (exitcode {self.proc.returncode})"
-            )
+        if self.proc:
+            if self.proc.poll() is not None:
+                raise RuntimeError(
+                    f"Virtual machine terminated (exitcode {self.proc.returncode})"
+                )
 
     def vfkit_command(self):
+        assert self.disk
         efi_store = store.vm_path(self.vm_name, "efi-variable-store")
         cmd = [
             self.driver_command or "vfkit",
@@ -182,6 +186,7 @@ class VM:
         return cmd
 
     def krunkit_command(self):
+        assert self.disk
         log_level = "4" if self.verbose else "3"
         cmd = [
             self.driver_command or "krunkit",
@@ -210,6 +215,7 @@ class VM:
         return cmd
 
     def qemu_command(self):
+        assert self.disk
         if self.fd is not None:
             netdev = f"dgram,id=net1,local.type=fd,local.str={self.fd}"
         elif self.socket is not None:

--- a/testing/vm.py
+++ b/testing/vm.py
@@ -57,11 +57,10 @@ class VM:
         """
         Starts a VM driver with fd or socket.
         """
-        vm_home = store.vm_path(self.vm_name)
-        os.makedirs(vm_home, exist_ok=True)
-
+        store.ensure_vm_dir(self.vm_name)
         self.disk = disks.create_disk(self)
         self.cidata = cidata.create_iso(self)
+
         if self.driver == "vfkit":
             cmd = self.vfkit_command()
         elif self.driver == "krunkit":
@@ -70,6 +69,7 @@ class VM:
             cmd = self.qemu_command()
         else:
             raise ValueError(f"Invalid driver '{self.driver}'")
+
         logging.info(
             "Starting '%s' virtual machine '%s' with mac address '%s'",
             self.driver,

--- a/testing/vm.py
+++ b/testing/vm.py
@@ -5,11 +5,11 @@ import logging
 import os
 import platform
 import socket
-import subprocess
 import time
 
 from . import cidata
 from . import disks
+from . import process
 from . import ssh
 from . import store
 
@@ -91,8 +91,8 @@ class VM:
             elif self.fd is not None:
                 pass_fds = [self.fd]
             self.write_command(cmd)
-            self.proc = subprocess.Popen(
-                cmd,
+            self.proc = process.start(
+                *cmd,
                 stdout=stdout,
                 stderr=log,
                 pass_fds=pass_fds,


### PR DESCRIPTION
Replace macos-15-intel runners with macos-26-intel for integration tests and unit tests. This requires running child processes as the unprivileged user when tests run as root via sudo.

### Why macos-26-intel?

macos-26-intel runners let us test with vmnet-broker and the new macOS 26 vmnet APIs. For integration tests we have limited resources so we prefer to test the latest version instead of legacy versions.

### What changed

The integration tests run as root via sudo (required for mDNS resolution). vmnet-helper drops privileges after starting the vmnet interface, so all files and sockets must be owned by the unprivileged user. We don't know how this worked on macos-15-intel runners.

- **testing.privileges**: Resolves the unprivileged user's UID/GID from SUDO_UID/SUDO_GID, matching how vmnet-helper itself drops privileges.

- **testing.process**: Central module for spawning child processes. Passes user/group to subprocess so curl, mkisofs, qemu-img, vfkit, and vmnet-helper all run as the unprivileged user.

- **testing.store**: New `ensure_vm_dir()` and `ensure_cache_dir()` create directories with correct ownership. Cannot use `os.makedirs()` since it doesn't support chown.

- **File ownership**: Cloud-init temp files, SSH config, and vmnet-helper log are chowned to the unprivileged user.

- **CI workflows**: Switch runners, install vmnet-broker on macos-26-intel, use matrix variable for vmnet-helper path in install tests.