### PR TITLE
Add fast/slow call counters and plot-stats tool

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -78,6 +78,9 @@ jobs:
           sudo --preserve-env HOME=$HOME .venv/bin/python3 ./run test \
               --driver ${{ matrix.driver }} \
               --connection ${{ matrix.connection }} \
+              --start-address 192.168.200.1 \
+              --end-address 192.168.200.127 \
+              --subnet-mask 255.255.255.0 \
               --stats-interval 1 \
               --timeout 300 \
               --verbose &

--- a/plot-stats
+++ b/plot-stats
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Contributors to the vmnet-helper project
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Generate benchmark comparison plots from vmnet-helper log files.
+
+Usage:
+    plot-stats [--title TITLE] [-o output-prefix] before.log after.log
+
+Output prefix defaults to the before log basename without extension.
+
+Generates two plots:
+    {output-prefix}-throughput.png  - bitrate and drops over time
+    {output-prefix}-efficiency.png  - fast and slow calls/sec over time
+
+Example:
+    % ./plot-stats --title "krunkit: iperf3 -c vm.local -P 4 -b 7G" \
+        krunkit-before/tx-p4-b7.log krunkit-after/tx-p4-b7.log
+    Saved: tx-p4-b7-throughput.png
+    Saved: tx-p4-b7-efficiency.png
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+import testing.stats
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--title", help="Plot title (default: output prefix)")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file prefix (default: before log basename without extension)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=5.0,
+        help="Steady state threshold in Gbps (default: 5.0)",
+    )
+    parser.add_argument("before", help="Before log file")
+    parser.add_argument("after", help="After log file")
+    args = parser.parse_args()
+
+    output_prefix = args.output or os.path.splitext(os.path.basename(args.before))[0]
+    title = args.title or output_prefix
+
+    before = steady_state(compute_rates(args.before), args.threshold)
+    after = steady_state(compute_rates(args.after), args.threshold)
+
+    if not before:
+        print(f"No steady state data in {args.before}", file=sys.stderr)
+        sys.exit(1)
+    if not after:
+        print(f"No steady state data in {args.after}", file=sys.stderr)
+        sys.exit(1)
+
+    plot_throughput(before, after, title, f"{output_prefix}-throughput.png")
+    plot_efficiency(before, after, title, f"{output_prefix}-efficiency.png")
+
+
+def compute_rates(logfile):
+    """Compute per-second rates from a log file."""
+    records = []
+    prev = None
+
+    for curr in testing.stats.parse(logfile):
+        if prev is not None:
+            t0 = datetime.fromisoformat(prev["time"])
+            t1 = datetime.fromisoformat(curr["time"])
+            duration = (t1 - t0).total_seconds()
+            if duration <= 0:
+                prev = curr
+                continue
+
+            delta = testing.stats.compute_delta(prev, curr)
+            record = {}
+            for ep in ("host", "vm"):
+                d = delta[ep]
+                record[ep] = {
+                    "bitrate_gbps": d["bytes"] * 8 / duration / 1e9,
+                    "packets": int(d["packets"] / duration),
+                    "drops": d["drops"],
+                    "fast": int(d["fast"] / duration),
+                    "slow": int(d["slow"] / duration),
+                }
+            records.append(record)
+
+        prev = curr
+
+    return records
+
+
+def steady_state(records, threshold=5.0):
+    return [r for r in records if r["host"]["bitrate_gbps"] > threshold]
+
+
+def plot_throughput(before, after, title, output_path):
+    n = min(len(before), len(after), 60)
+    before = before[:n]
+    after = after[:n]
+    t = list(range(1, n + 1))
+
+    before_bitrate = [r["host"]["bitrate_gbps"] for r in before]
+    after_bitrate = [r["host"]["bitrate_gbps"] for r in after]
+    before_drops = [r["host"]["drops"] for r in before]
+    after_drops = [r["host"]["drops"] for r in after]
+
+    fig, ax1 = plt.subplots(figsize=(12, 5))
+
+    ax1.set_xlabel("Time (seconds)", fontsize=12)
+    ax1.set_ylabel("Host\u2192VM Bitrate (Gbits/sec)", fontsize=12)
+    ax1.plot(
+        t,
+        before_bitrate,
+        color="#2196F3",
+        linewidth=1.5,
+        label="Before - bitrate",
+        alpha=0.9,
+    )
+    ax1.plot(
+        t,
+        after_bitrate,
+        color="#FF9800",
+        linewidth=1.5,
+        label="After - bitrate",
+        alpha=0.9,
+    )
+
+    max_br = max(max(before_bitrate), max(after_bitrate))
+    min_br = min(min(before_bitrate), min(after_bitrate))
+    margin = (max_br - min_br) * 0.15 or 1
+    ax1.set_ylim(min_br - margin, max_br + margin)
+
+    ax2 = ax1.twinx()
+    ax2.set_ylabel("Host\u2192VM Drops", fontsize=12)
+    ax2.bar(
+        [x - 0.15 for x in t],
+        before_drops,
+        width=0.3,
+        color="#90CAF9",
+        alpha=0.7,
+        label="Before - drops",
+    )
+    ax2.bar(
+        [x + 0.15 for x in t],
+        after_drops,
+        width=0.3,
+        color="#FFCC80",
+        alpha=0.7,
+        label="After - drops",
+    )
+
+    max_drops = max(max(before_drops), max(after_drops))
+    ax2.set_ylim(0, max(max_drops * 1.5, 1))
+
+    lines1, labels1 = ax1.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax1.legend(lines1 + lines2, labels1 + labels2, loc="lower left", fontsize=10)
+
+    ax1.set_title(title, fontsize=14, fontweight="bold")
+    ax1.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+def plot_efficiency(before, after, title, output_path):
+    n = min(len(before), len(after), 60)
+    before = before[:n]
+    after = after[:n]
+    t = list(range(1, n + 1))
+
+    before_fast = [r["host"]["fast"] for r in before]
+    after_fast = [r["host"]["fast"] for r in after]
+    before_slow = [r["host"]["slow"] for r in before]
+    after_slow = [r["host"]["slow"] for r in after]
+
+    fig, ax1 = plt.subplots(figsize=(12, 5))
+
+    ax1.set_xlabel("Time (seconds)", fontsize=12)
+    ax1.set_ylabel("Fast calls/sec", fontsize=12)
+    ax1.plot(
+        t,
+        before_fast,
+        color="#2196F3",
+        linewidth=1.5,
+        label="Before - fast calls",
+        alpha=0.9,
+    )
+    ax1.plot(
+        t,
+        after_fast,
+        color="#FF9800",
+        linewidth=1.5,
+        label="After - fast calls",
+        alpha=0.9,
+    )
+
+    max_val = max(max(before_fast), max(after_fast))
+    min_val = min(min(before_fast), min(after_fast))
+    margin = (max_val - min_val) * 0.15 or 500
+    ax1.set_ylim(min_val - margin, max_val + margin)
+
+    ax2 = ax1.twinx()
+    ax2.set_ylabel("Slow calls/sec", fontsize=12)
+    ax2.bar(
+        [x - 0.15 for x in t],
+        before_slow,
+        width=0.3,
+        color="#90CAF9",
+        alpha=0.7,
+        label="Before - slow calls",
+    )
+    ax2.bar(
+        [x + 0.15 for x in t],
+        after_slow,
+        width=0.3,
+        color="#FFCC80",
+        alpha=0.7,
+        label="After - slow calls",
+    )
+
+    max_slow = max(max(before_slow), max(after_slow))
+    ax2.set_ylim(0, max(max_slow * 1.5, 1))
+
+    lines1, labels1 = ax1.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax1.legend(lines1 + lines2, labels1 + labels2, loc="upper left", fontsize=10)
+
+    ax1.set_title(title + " (efficiency)", fontsize=14, fontweight="bold")
+    ax1.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/programs/helper.c
+++ b/programs/helper.c
@@ -76,6 +76,8 @@ struct forward_stats {
     uint64_t packets;   // packets forwarded
     uint64_t bytes;     // bytes forwarded
     uint64_t drops;     // packets dropped
+    uint64_t fast;      // fast path calls (recvmsg_x, sendmsg_x)
+    uint64_t slow;      // slow path calls (read, write)
 };
 
 struct endpoint {
@@ -847,18 +849,17 @@ static void write_to_vm(int count)
 
     int packets = 0;
     size_t bytes = 0;
+    uint64_t fast = 0;
 
     // Fast path.
 
     if (use_bulk_forwarding) {
-        uint64_t retries = 0;
-
         while (1) {
+            fast++;
             ssize_t n = sendmsg_x(options.fd, &host.msgs[packets], count-packets, 0);
             if (n == -1) {
                 if (errno == ENOBUFS) {
                     wait_for_buffer_space();
-                    retries++;
                     continue;
                 }
 
@@ -872,9 +873,10 @@ static void write_to_vm(int count)
                 bytes = host_packets_size(packets);
                 host.stats.packets += packets;
                 host.stats.bytes += bytes;
+                host.stats.fast += fast;
 
-                DEBUGF("[host->vm] forwarded %d packets %zu bytes %lld retries",
-                        packets, bytes, retries);
+                DEBUGF("[host->vm] forwarded %d packets %zu bytes %llu fast",
+                        packets, bytes, fast);
                 return;
             }
         }
@@ -882,6 +884,7 @@ static void write_to_vm(int count)
 
     // Slow path.
 
+    uint64_t slow = 0;
     int drops = 0;
 
     for (int i = packets; i < count; i++) {
@@ -890,6 +893,7 @@ static void write_to_vm(int count)
         uint64_t retries = 0;
 
         while (1) {
+            slow++;
             len = write(options.fd, packet->vm_pkt_iov[0].iov_base,
                     packet->vm_pkt_size);
             if (len == -1 && errno == ENOBUFS) {
@@ -920,9 +924,11 @@ static void write_to_vm(int count)
     host.stats.packets += packets;
     host.stats.bytes += bytes;
     host.stats.drops += drops;
+    host.stats.fast += fast;
+    host.stats.slow += slow;
 
-    DEBUGF("[host->vm] forwarded %d packets %zu bytes %d drops",
-            packets, bytes, drops);
+    DEBUGF("[host->vm] forwarded %d packets %zu bytes %d drops %llu fast %llu slow",
+            packets, bytes, drops, fast, slow);
 }
 
 static void packets_available(xpc_object_t event)
@@ -971,6 +977,7 @@ static int read_from_vm(void)
             vm.iovs[i].iov_len = max_packet_size;
         }
 
+        vm.stats.fast++;
         int count = recvmsg_x(options.fd, vm.msgs, max_packets, 0);
         if (count != -1) {
             return count;
@@ -982,6 +989,7 @@ static int read_from_vm(void)
     // Slow path - read one packet.
 
     vm.iovs[0].iov_len = max_packet_size;
+    vm.stats.slow++;
     int len = read(options.fd, vm.iovs[0].iov_base, vm.iovs[0].iov_len);
     if (len == -1) {
         ERRORF("[vm->host] read: %s", strerror(errno));
@@ -1086,21 +1094,29 @@ static void report_stats(void) {
             "\"host\": {"
                 "\"packets\": %llu, "
                 "\"bytes\": %llu, "
-                "\"drops\": %llu"
+                "\"drops\": %llu, "
+                "\"fast\": %llu, "
+                "\"slow\": %llu"
             "}, "
             "\"vm\": {"
                 "\"packets\": %llu, "
                 "\"bytes\": %llu, "
-                "\"drops\": %llu"
+                "\"drops\": %llu, "
+                "\"fast\": %llu, "
+                "\"slow\": %llu"
             "}"
         "}",
         timestamp,
         host.stats.packets,
         host.stats.bytes,
         host.stats.drops,
+        host.stats.fast,
+        host.stats.slow,
         vm.stats.packets,
         vm.stats.bytes,
-        vm.stats.drops);
+        vm.stats.drops,
+        vm.stats.fast,
+        vm.stats.slow);
 }
 
 static void start_stats_timer(void) {

--- a/stats
+++ b/stats
@@ -13,7 +13,7 @@ from datetime import datetime
 
 import testing
 
-COUNTER_FIELDS = ["packets", "bytes", "drops"]
+COUNTER_FIELDS = ["packets", "bytes", "drops", "fast", "slow"]
 
 KiB = 1024
 MiB = 1024 * KiB
@@ -62,13 +62,17 @@ def print_yaml(prev, curr):
     print(f"- time: {curr['time']}")
     for endpoint in ("host", "vm"):
         d = delta[endpoint]
-        bps = d["bytes"] / duration
-        pps = int(d["packets"] / duration)
+        bytes_ps = d["bytes"] / duration
+        packets_ps = int(d["packets"] / duration)
+        fast_ps = int(d["fast"] / duration)
+        slow_ps = int(d["slow"] / duration)
         print(f"  {endpoint}:")
         print(f"    transfer: {format_bytes(d['bytes'])}")
-        print(f"    bitrate: {format_bits_per_sec(bps)}")
-        print(f"    packets: {pps} pkt/sec")
+        print(f"    bitrate: {format_bits_per_sec(bytes_ps)}")
+        print(f"    packets: {packets_ps} pkt/sec")
         print(f"    drops: {d['drops']}")
+        print(f"    fast: {fast_ps} calls/sec")
+        print(f"    slow: {slow_ps} calls/sec")
 
 
 def compute_delta(prev, curr):

--- a/stats
+++ b/stats
@@ -11,9 +11,7 @@ import json
 import sys
 from datetime import datetime
 
-import testing
-
-COUNTER_FIELDS = ["packets", "bytes", "drops", "fast", "slow"]
+import testing.stats
 
 KiB = 1024
 MiB = 1024 * KiB
@@ -34,7 +32,7 @@ def main():
 
     prev = None
 
-    for curr in testing.helper.parse_stats(args.logfile):
+    for curr in testing.stats.parse(args.logfile):
         # Skip the first sample since we need two samples to compute
         # the interval duration for rate calculation.
         if prev is not None:
@@ -47,7 +45,7 @@ def main():
 
 
 def print_json(prev, curr):
-    delta = {"time": curr["time"], **compute_delta(prev, curr)}
+    delta = {"time": curr["time"], **testing.stats.compute_delta(prev, curr)}
     print(json.dumps(delta))
 
 
@@ -58,7 +56,7 @@ def print_yaml(prev, curr):
     if duration <= 0:
         return
 
-    delta = compute_delta(prev, curr)
+    delta = testing.stats.compute_delta(prev, curr)
     print(f"- time: {curr['time']}")
     for endpoint in ("host", "vm"):
         d = delta[endpoint]
@@ -73,16 +71,6 @@ def print_yaml(prev, curr):
         print(f"    drops: {d['drops']}")
         print(f"    fast: {fast_ps} calls/sec")
         print(f"    slow: {slow_ps} calls/sec")
-
-
-def compute_delta(prev, curr):
-    delta = {}
-    for endpoint in ("host", "vm"):
-        delta[endpoint] = {
-            field: curr[endpoint][field] - prev[endpoint][field]
-            for field in COUNTER_FIELDS
-        }
-    return delta
 
 
 def format_bytes(n):

--- a/testing/helper.py
+++ b/testing/helper.py
@@ -212,17 +212,3 @@ def shared_interfaces():
         check=True,
     )
     return cp.stdout.decode().splitlines()
-
-
-_STATS_RE = re.compile(r"\[stats\] (\{.*\})")
-
-
-def parse_stats(logfile):
-    """
-    Yield parsed stats entries from a vmnet-helper log file.
-    """
-    with open(logfile) as f:
-        for line in f:
-            m = _STATS_RE.search(line)
-            if m:
-                yield json.loads(m.group(1))

--- a/testing/helper_test.py
+++ b/testing/helper_test.py
@@ -32,6 +32,7 @@ from scapy.all import ARP, ICMP, IP, Ether  # type: ignore[import-untyped]
 
 from . import helper
 from . import mac
+from . import stats
 from .helper import (
     NET_IPV4_MASK,
     NET_IPV4_SUBNET,
@@ -434,12 +435,12 @@ class TestStats:
             # Wait for the stats timer to fire.
             time.sleep(1.5)
 
-        stats = list(helper.parse_stats(h.logfile))
-        assert len(stats) > 0, "No stats found in log"
-        for s in stats:
+        entries = list(stats.parse(h.logfile))
+        assert len(entries) > 0, "No stats found in log"
+        for s in entries:
             log.debug("stats: %s", s)
 
-        entry = stats[0]
+        entry = entries[0]
         assert "time" in entry
         datetime.fromisoformat(entry["time"])
         for endpoint in ("host", "vm"):
@@ -460,8 +461,8 @@ class TestStats:
 
             time.sleep(1.5)
 
-        stats = list(helper.parse_stats(h.logfile))
-        assert len(stats) == 0, "Stats should not be logged by default"
+        entries = list(stats.parse(h.logfile))
+        assert len(entries) == 0, "Stats should not be logged by default"
 
 
 # --- Helper runner ---

--- a/testing/stats.py
+++ b/testing/stats.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import re
+
+COUNTER_FIELDS = ["packets", "bytes", "drops", "fast", "slow"]
+
+_STATS_RE = re.compile(r"\[stats\] (\{.*\})")
+
+
+def parse(logfile):
+    """
+    Yield parsed stats entries from a vmnet-helper log file.
+    """
+    with open(logfile) as f:
+        for line in f:
+            m = _STATS_RE.search(line)
+            if m:
+                yield json.loads(m.group(1))
+
+
+def compute_delta(prev, curr):
+    """
+    Compute the difference between two stats entries.
+    """
+    delta = {}
+    for endpoint in ("host", "vm"):
+        delta[endpoint] = {
+            field: curr[endpoint][field] - prev[endpoint][field]
+            for field in COUNTER_FIELDS
+        }
+    return delta


### PR DESCRIPTION
## Summary

- Add `fast` and `slow` counters to track system calls in the forwarding
  paths, measuring batching efficiency and detecting fallback to the slow path
- Move stats parsing into `testing.stats` module for reuse across scripts
- Add `plot-stats` tool for generating before/after benchmark comparison plots

## Details

The `fast` counter tracks `sendmsg_x`/`recvmsg_x` calls (including retries),
the `slow` counter tracks `read`/`write` calls. The key metric is packets per
fast call -- higher means better batching. A non-zero slow count indicates
fallback from bulk forwarding.

These counters prepare for upcoming work on ENOBUFS retry limits (#267), where
comparing call counts before and after will show whether the change improves
batching efficiency.

The `plot-stats` tool generates throughput and efficiency comparison plots from
two log files:

    % ./plot-stats --title "krunkit: iperf3 -c vm.local -P 4 -b 7G" \
        krunkit-before/tx-p4-b7.log krunkit-after/tx-p4-b7.log
    Saved: tx-p4-b7-throughput.png
    Saved: tx-p4-b7-efficiency.png