### PR TITLE
Increase receive buffer size for offloading

### DIFF
--- a/programs/common.h
+++ b/programs/common.h
@@ -14,8 +14,12 @@
 
 // The receive buffer size determines how many packets can be queued by the
 // peer. Testing shows good performance with a 2 MiB receive buffer. We use a 4
-// MiB buffer to make ENOBUFS errors less likely for the peer and allowing to
-// queue more packets when using the vmnet_enable_tso option.
+// MiB buffer to make ENOBUFS errors less likely for the peer.
 #define RECV_BUFFER_SIZE (4 * 1024 * 1024)
+
+// Scale buffer for higher offloading throughput (~2.5x). A larger factor would
+// reduce ENOBUFS but adds latency from bufferbloat. With 8 MiB the buffer
+// fills in ~2 ms, similar to ~2.6 ms without offloading.
+#define RECV_BUFFER_SIZE_OFFLOAD (8 * 1024 * 1024)
 
 #endif // COMMON_H

--- a/programs/helper.c
+++ b/programs/helper.c
@@ -651,7 +651,8 @@ static void set_socket_buffers(int fd)
         WARNF("[main] setsockopt: %s", strerror(errno));
     }
 
-    const int rcvbuf_size = RECV_BUFFER_SIZE;
+    int rcvbuf_size = options.enable_tso ? RECV_BUFFER_SIZE_OFFLOAD : RECV_BUFFER_SIZE;
+
     if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf_size, sizeof(rcvbuf_size)) < 0) {
         WARNF("[main] setsockopt: %s", strerror(errno));
     }

--- a/programs/run.c
+++ b/programs/run.c
@@ -396,7 +396,8 @@ static void set_socket_buffers(int fd)
         WARNF("[runner] setsockopt: %s", strerror(errno));
     }
 
-    const int rcvbuf_size = RECV_BUFFER_SIZE;
+    int rcvbuf_size = options.enable_tso ? RECV_BUFFER_SIZE_OFFLOAD : RECV_BUFFER_SIZE;
+
     if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf_size, sizeof(rcvbuf_size)) < 0) {
         WARNF("[runner] setsockopt: %s", strerror(errno));
     }

--- a/run
+++ b/run
@@ -198,7 +198,7 @@ def run_with_fd(args):
     """
     # Create a socketpair for the child processes. The vm_sock will be used by
     # the vm, and the host_sock will be used by the helper.
-    vm_sock, helper_sock = testing.socketpair()
+    vm_sock, helper_sock = testing.socketpair(args.enable_offloading)
 
     # Start vmnet-helper first, since we need the MAC address before starting
     # the VM.

--- a/testing/helper.py
+++ b/testing/helper.py
@@ -29,9 +29,13 @@ SEND_BUFFER_SIZE = 65 * 1024
 
 # The receive buffer size determines how many packets can be queued by the peer.
 # Testing shows good performance with a 2 MiB receive buffer. We use a 4 MiB
-# buffer to make ENOBUFS errors less likely for the peer and allowing to queue
-# more packets when using the vmnet_enable_tso option.
+# buffer to make ENOBUFS errors less likely for the peer.
 RECV_BUFFER_SIZE = 4 * 1024 * 1024
+
+# Scale buffer for higher offloading throughput (~2.5x). A larger factor would
+# reduce ENOBUFS but adds latency from bufferbloat. With 8 MiB the buffer fills
+# in ~2 ms, similar to ~2.6 ms without offloading.
+RECV_BUFFER_SIZE_OFFLOAD = 8 * 1024 * 1024
 
 # Vmnet interface info keys
 # https://developer.apple.com/documentation/vmnet/interface_param_xpc_dictionary_keys?language=objc
@@ -196,11 +200,14 @@ def interface_id_from(name):
     return str(uuid.UUID(bytes=md[:16], version=4))
 
 
-def socketpair():
+def socketpair(offloading=False):
     pair = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM, 0)
+
+    recv_buffer_size = RECV_BUFFER_SIZE_OFFLOAD if offloading else RECV_BUFFER_SIZE
+
     for sock in pair:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, SEND_BUFFER_SIZE)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, RECV_BUFFER_SIZE)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, recv_buffer_size)
         os.set_inheritable(sock.fileno(), True)
     return pair
 

--- a/testing/helper_test.py
+++ b/testing/helper_test.py
@@ -512,7 +512,7 @@ def run_helper(
 
     logfile = str(tmp_path / "vmnet-helper.log") if tmp_path else None
 
-    host_sock, vm_sock = helper.socketpair()
+    host_sock, vm_sock = helper.socketpair(enable_offloading)
     try:
         h = helper.Helper(
             args,


### PR DESCRIPTION
With offloading enabled, throughput is ~2.5x higher than without. Without adjusting the receive buffer, it fills in ~1 ms vs ~2.6 ms without offloading, causing more ENOBUFS errors for the peer.

Use a dedicated 8 MiB constant (RECV_BUFFER_SIZE_OFFLOAD) that keeps fill-time at ~2 ms — similar to the non-offloading case. A larger buffer would further reduce ENOBUFS but adds latency from bufferbloat.

Define the constant in common.h and helper.py so the value and rationale are documented in one place per language, rather than duplicating the multiplier logic at each call site.