### PR TITLE
run: add --busy-poll option for higher benchmark throughput

### DIFF
--- a/bench
+++ b/bench
@@ -204,6 +204,8 @@ class VM:
             cmd.append(f"--driver-command={self.driver['command']}")
         if self.driver.get("offloading", False):
             cmd.append("--enable-offloading")
+        cmd.append("--busy-poll")
+        cmd.append("--stats-interval=1")
 
         print(f"Starting process {cmd}")
         self.proc = subprocess.Popen(cmd)

--- a/docs/development.md
+++ b/docs/development.md
@@ -143,6 +143,36 @@ The following example uses the qemu driver, and connects using vmnet-run:
 [  16.630] INFO VM is ready at test-vmnet-helper.local
 ```
 
+### Performance tuning
+
+By default, VMs use interrupt-driven packet processing. During high
+throughput TX benchmarks (host sending to the VM), `ksoftirqd` saturates
+a single CPU core in the guest, limiting throughput to ~30 Gbps. RX
+throughput (VM sending to the host) is not affected since the host does
+the heavy packet processing.
+
+The `--busy-poll` option enables busy polling in the VM, shifting packet
+processing from `ksoftirqd` to the application threads:
+
+```console
+% ./run test --busy-poll
+```
+
+With busy polling, TX throughput improves to ~37 Gbps. This works by
+configuring `net.core.busy_poll` and `net.core.busy_read` via
+cloud-init. When the application calls `recv()` or `poll()` and no data
+is ready, the kernel polls the virtio RX ring for up to 50 microseconds
+before falling back to interrupt-driven processing.
+
+Busy polling increases CPU usage when the VM is idle, so the default
+(without `--busy-poll`) represents the expected performance for general
+purpose workloads. Use `--busy-poll` for benchmarking to measure
+vmnet-helper TX throughput without guest-side bottlenecks.
+
+> [!NOTE]
+> Requires `CONFIG_NET_RX_BUSY_POLL=y` in the guest kernel. This is
+> enabled by default in Ubuntu, Fedora, Debian, and Alpine.
+
 ### Storage and debugging
 
 The script downloads cloud images to `~/.vmnet-helper/cache/images`, converts

--- a/run
+++ b/run
@@ -144,6 +144,14 @@ def main():
         help="Comma-separated DNS servers for the VM (8.8.8.8,1.1.1.1)",
     )
 
+    # Performance tuning
+
+    p.add_argument(
+        "--busy-poll",
+        action="store_true",
+        help="Enable busy polling in the VM for higher network throughput",
+    )
+
     # Debugging
 
     p.add_argument("-v", "--verbose", action="store_true", help="Be more verbose")

--- a/testing/cidata.py
+++ b/testing/cidata.py
@@ -12,6 +12,21 @@ import yaml
 
 from . import store
 
+# Enable busy polling for network sockets to reduce softirq overhead.
+# Without this, ksoftirqd saturates a single CPU core during high
+# throughput benchmarks, limiting performance to ~30 Gbps. With busy
+# polling, packet processing shifts to the application threads,
+# reaching ~37 Gbps. Requires CONFIG_NET_RX_BUSY_POLL=y in the guest
+# kernel (enabled by default in Ubuntu, Fedora, Debian, and Alpine).
+# This increases CPU usage when the VM is idle, so it is only
+# appropriate for benchmark VMs, not general purpose workloads.
+# Applied via bootcmd so it runs on every boot and is absent when
+# --busy-poll is not used.
+_BUSY_POLL_CMDS = [
+    "sysctl -w net.core.busy_poll=50",
+    "sysctl -w net.core.busy_read=50",
+]
+
 # Distro-specific cloud-init user-data configuration. Keys match
 # cloud-init module names so the dict can be merged directly into the
 # user-data.
@@ -122,6 +137,8 @@ def create_user_data(vm):
         "ssh_authorized_keys": public_keys(),
     }
     data.update(DISTROS[vm.distro])
+    if vm.busy_poll:
+        data.setdefault("bootcmd", []).extend(_BUSY_POLL_CMDS)
     return data
 
 

--- a/testing/vm.py
+++ b/testing/vm.py
@@ -43,6 +43,7 @@ class VM:
         self.memory = args.memory
         self.distro = args.distro
         self.dns_servers = args.dns_servers
+        self.busy_poll = args.busy_poll
         self.serial = store.vm_path(self.vm_name, "serial.log")
         self.enable_offloading = args.enable_offloading
 


### PR DESCRIPTION
During high throughput TX benchmarks (host sending to the VM), the guest spends significant CPU time on interrupt-driven packet processing. Busy polling shifts packet processing to the application threads by configuring net.core.busy_poll and net.core.busy_read in the guest via cloud-init bootcmd.

The settings are applied on every boot when --busy-poll is used, and are absent otherwise. This avoids persistent sysctl files that would linger when --busy-poll is not used.

The default (without --busy-poll) represents the expected performance for general purpose workloads. Use --busy-poll for benchmarking to measure vmnet-helper throughput without guest-side bottlenecks.

Tested with iperf3 -P 4 using krunkit with 4 CPUs, offloading enabled, and 8 MiB receive buffer:

                 TX (Gbps)    RX (Gbps)    Bidir TX+RX (Gbps)
    default          30.2         42.7         23.6 + 17.5
    --busy-poll      36.4         42.7         22.8 + 19.7

TX throughput improves by ~20%. The helper's fast calls/sec is the same (~14.5k) in both cases, confirming the improvement is purely guest-side. RX is unaffected since the host does the heavy packet processing. Bidir total is similar, with busy polling shifting throughput from TX to RX.