### PR TITLE
Revert "ci: Flush mDNS cache before starting test VM"

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -66,10 +66,6 @@ jobs:
         run: |
           python3 -m venv .venv
           .venv/bin/pip install pyyaml
-      - name: Flush mDNS cache
-        run: |
-          sudo dscacheutil -flushcache
-          sudo killall -HUP mDNSResponder
       - name: Start example VM
         run: |
           # NOTE: Run as root to allow mDNS resolution and checking guest


### PR DESCRIPTION
We still have random timeouts waiting for the VM. Flushing the cache does not seem to help, so let's simplify.

This reverts commit 21c62c843b70537b1e560e4572ee1916c97a275e.