### PR TITLE
integration: Increase vm start timeout to 600s

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -78,11 +78,11 @@ jobs:
               --end-address 192.168.200.127 \
               --subnet-mask 255.255.255.0 \
               --stats-interval 1 \
-              --timeout 300 \
+              --timeout 600 \
               --verbose &
           pid=$!
           echo $pid > test.pid
-          if ! timeout 300s bash -c "until nc -z test-vmnet-helper.local 22 2>/dev/null; do true; done"; then
+          if ! timeout 600s bash -c "until nc -z test-vmnet-helper.local 22 2>/dev/null; do true; done"; then
               echo >&2 "Timeout waiting for test-vmnet-helper.local"
               exit 1
           fi


### PR DESCRIPTION
GitHub Intel Mac runners (macos-15-intel) have become slower recently, increasing VM boot times from ~2:30-3:00 minutes to ~3:30-4:40 minutes. With a 300s timeout, the margin was only ~20 seconds, risking spurious failures.

"Start example VM" step duration across recent CI runs:

    Date              Branch                  VM start range
    Jul 19            main                    2:30 - 3:00
    Jul 20            bounded-enobufs-retry   2:30 - 3:00
    Jul 26 02:30 UTC  stats                   2:50 - 4:30
    Jul 27 12:15 UTC  plot-stats              2:57 - 4:07
    Jul 27 17:10 UTC  revert-mdns-flush       3:23 - 4:40
    Jul 27 17:25 UTC  adaptive-buffer         2:56 - 3:51

All drivers (qemu, vfkit) and connection types (fd, socket, runner) are affected equally, confirming the slowdown is runner-level, not code-related.

Increase both the `./run test --timeout` and the `nc` wait timeout from 300s to 600s.