### PR TITLE
Add `brew trust` for Homebrew 6.0 tap trust requirement

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -71,6 +71,7 @@ jobs:
         if: matrix.method == 'brew'
         run: |
           brew tap nirs/vmnet-helper
+          brew trust nirs/vmnet-helper
           brew install vmnet-helper
 
       - name: Install via script (local)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Install using [Homebrew](https://brew.sh/):
 
 ```console
 brew tap nirs/vmnet-helper
+brew trust nirs/vmnet-helper
 brew install vmnet-helper
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -14,6 +14,7 @@ To install the requirements for creating virtual machine using *vfkit*
 
 ```console
 brew tap libkrun/krun
+brew trust libkrun/krun
 brew install python3 vfkit krunkit qemu cdrtools
 python3 -m venv .venv
 source .venv/bin/activate

--- a/docs/freebsd.md
+++ b/docs/freebsd.md
@@ -26,6 +26,7 @@ built-in DHCP server.
 
 ```console
 brew tap nirs/vmnet-helper
+brew trust nirs/vmnet-helper
 brew install vmnet-helper cdrtools qemu
 ```
 

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -24,6 +24,7 @@ Install using [Homebrew](https://brew.sh/):
 
 ```console
 brew tap nirs/vmnet-helper
+brew trust nirs/vmnet-helper
 brew install vmnet-helper vfkit cdrtools qemu
 ```
 

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -33,7 +33,9 @@ offloading delivers 2.3x to 30.2x faster networking compared to podman machine
 
 ```console
 brew tap nirs/vmnet-helper
+brew trust nirs/vmnet-helper
 brew tap libkrun/krun
+brew trust libkrun/krun
 brew install vmnet-helper vfkit krunkit cdrtools qemu
 ```
 


### PR DESCRIPTION
Homebrew 6.0.0 requires explicit trust for non-official taps before their code is evaluated. Without `brew trust`, `brew install` fails for formulae from third-party taps.

See https://docs.brew.sh/Tap-Trust for details.

Fixes: #280