### PR TITLE
test: Drop unnecessary sudo from integration workflow

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -94,11 +94,11 @@ jobs:
           vm_files=$(find "$vm" -name "*.command" -or -name "*.log")
           for f in $vm_files; do
             echo "==> $f <=="
-            sudo head -n 500 "$f" || true
+            head -n 500 "$f" || true
           done
           echo "==> /var/db/dhcpd_leases <=="
           ls -l /var/db/dhcpd_leases || true
-          sudo head -n 500 /var/db/dhcpd_leases || true
+          head -n 500 /var/db/dhcpd_leases || true
       - name: Inspect VM guest data
         run: |
           echo "uname: $(ssh test -- uname -a)"
@@ -148,7 +148,7 @@ jobs:
               -not -name "initrd" \
               > artifacts.txt
           test -f /var/db/dhcpd_leases && echo /var/db/dhcpd_leases >> artifacts.txt
-          sudo tar --create --gzip \
+          tar --create --gzip \
               --file vmnet-helper-integration-${{ matrix.driver }}-${{ matrix.connection }}.tar.gz \
               --files-from artifacts.txt
       - name: Upload logs


### PR DESCRIPTION
Since child processes and files are now created as the unprivileged user, sudo is no longer needed for reading log files or creating the artifacts tarball.

/var/db/dhcpd_leases is world-readable (mode 644) so it also does not require sudo.

The remaining sudo commands cannot be removed:
- mdutil requires root for disabling Spotlight indexing.
- The test suite runs via sudo for mDNS registration access.
- kill needs sudo because it targets the sudo wrapper process.