### PR TITLE
Switch to Ubuntu Minimal cloud image

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -78,11 +78,11 @@ jobs:
               --end-address 192.168.200.127 \
               --subnet-mask 255.255.255.0 \
               --stats-interval 1 \
-              --timeout 600 \
+              --timeout 300 \
               --verbose &
           pid=$!
           echo $pid > test.pid
-          if ! timeout 600s bash -c "until nc -z test-vmnet-helper.local 22 2>/dev/null; do true; done"; then
+          if ! timeout 300s bash -c "until nc -z test-vmnet-helper.local 22 2>/dev/null; do true; done"; then
               echo >&2 "Timeout waiting for test-vmnet-helper.local"
               exit 1
           fi

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -90,6 +90,8 @@ users:
       - "$(cat ~/.ssh/id_ed25519.pub)"
 packages:
   - avahi-daemon
+bootcmd:
+  - systemctl mask systemd-networkd-wait-online.service
 EOF
 
 cat > ~/vms/$VM_NAME/meta-data << EOF

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -41,13 +41,13 @@ brew install docker vmnet-helper krunkit cdrtools qemu
 > Docker Desktop — you can keep both and switch between them using
 > `docker context use`.
 
-## Download an Ubuntu 26.04 cloud image
+## Download an Ubuntu 26.04 minimal cloud image
 
-Download an Ubuntu cloud image and convert to raw:
+Download an Ubuntu minimal cloud image and convert to raw:
 
 ```console
 curl --fail --location --output /tmp/ubuntu-26.04.qcow2 \
-    https://cloud-images.ubuntu.com/releases/26.04/release/ubuntu-26.04-server-cloudimg-arm64.img
+    https://cloud-images.ubuntu.com/minimal/releases/resolute/release/ubuntu-26.04-minimal-cloudimg-arm64.img
 mkdir -p ~/.cache/vm-images
 qemu-img convert -f qcow2 -O raw /tmp/ubuntu-26.04.qcow2 \
     ~/.cache/vm-images/ubuntu-26.04.img

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -26,7 +26,7 @@ To start a virtual machine using *vfkit* run:
 ```console
 % ./run vm
 [   0.038] INFO Starting vmnet-helper for 'vm' with interface id '391ea262-d812-45b9-9526-e0ab5aeff7a2'
-[   0.058] INFO Downloading image 'https://cloud-images.ubuntu.com/releases/25.04/release/ubuntu-25.04-server-cloudimg-arm64.img'
+[   0.058] INFO Downloading image 'https://cloud-images.ubuntu.com/minimal/releases/resolute/release/ubuntu-26.04-minimal-cloudimg-arm64.img'
 [  19.384] INFO Converting image to 'raw' format '/Users/nir/.vmnet-helper/cache/images/7fef961f75d830af5d20db6da02bff7e33ce662a49bd4b433ed8f35a9f6a18c0/data'
 [  21.558] INFO Resizing image to 20g
 [  21.585] INFO Creating image '/Users/nir/.vmnet-helper/vms/vm/disk.img'

--- a/examples/download.sh
+++ b/examples/download.sh
@@ -16,7 +16,7 @@ curl \
     --fail \
     --location \
     --output "$TMP_IMAGE" \
-    "https://cloud-images.ubuntu.com/releases/25.04/release/ubuntu-25.04-server-cloudimg-$IMAGE_ARCH.img"
+    "https://cloud-images.ubuntu.com/minimal/releases/resolute/release/ubuntu-26.04-minimal-cloudimg-$IMAGE_ARCH.img"
 
 # Convert to raw so we can use this image for vfkit.
 qemu-img convert -f qcow2 -O raw "$TMP_IMAGE" "$DISK_IMAGE"

--- a/testing/cidata.py
+++ b/testing/cidata.py
@@ -36,6 +36,12 @@ DISTROS = {
     # Ubuntu auto-enables and starts daemons on package install.
     "ubuntu": {
         "packages": ["avahi-daemon"],
+        # systemd-networkd-wait-online may block boot for 2 minutes waiting
+        # for all interfaces to be fully configured. We only need eth0
+        # (DHCP from vmnet) and don't care about the online target.
+        "bootcmd": [
+            "systemctl mask systemd-networkd-wait-online.service",
+        ],
     },
     "fedora": {
         "packages": ["avahi"],

--- a/testing/disks.py
+++ b/testing/disks.py
@@ -31,6 +31,8 @@ IMAGES = {
                 # Based on socket_vmnet fix:
                 # https://github.com/lima-vm/socket_vmnet/pull/56
                 "no_timer_check",
+                # May block boot for 2 minutes waiting for all interfaces.
+                "systemd.mask=systemd-networkd-wait-online.service",
             ],
         },
     },

--- a/testing/disks.py
+++ b/testing/disks.py
@@ -14,15 +14,15 @@ UBUNTU_RELEASE = "26.04"
 IMAGES = {
     "ubuntu": {
         "arm64": {
-            "image": f"https://cloud-images.ubuntu.com/releases/{UBUNTU_RELEASE}/release/ubuntu-{UBUNTU_RELEASE}-server-cloudimg-arm64.img",
+            "image": f"https://cloud-images.ubuntu.com/minimal/releases/resolute/release/ubuntu-{UBUNTU_RELEASE}-minimal-cloudimg-arm64.img",
         },
         "x86_64": {
-            "image": f"https://cloud-images.ubuntu.com/releases/{UBUNTU_RELEASE}/release/ubuntu-{UBUNTU_RELEASE}-server-cloudimg-amd64.img",
-            "kernel": f"https://cloud-images.ubuntu.com/releases/{UBUNTU_RELEASE}/release/unpacked/ubuntu-{UBUNTU_RELEASE}-server-cloudimg-amd64-vmlinuz-generic",
+            "image": f"https://cloud-images.ubuntu.com/minimal/releases/resolute/release/ubuntu-{UBUNTU_RELEASE}-minimal-cloudimg-amd64v3.img",
+            "kernel": f"https://cloud-images.ubuntu.com/minimal/releases/resolute/release/unpacked/ubuntu-{UBUNTU_RELEASE}-minimal-cloudimg-amd64v3-vmlinuz-generic",
             # Based on the default kernel cmdline when not using kernel and initrd:
             # BOOT_IMAGE=/vmlinuz-6.11.0-14-generic root=LABEL=cloudimg-rootfs ro console=tty1 console=ttyS0
             "kernel_parameters": [
-                "root=LABEL=cloudimg-rootfs",
+                "root=/dev/vda1",
                 "ro",
                 "console=tty1",
                 "console=ttyS0",
@@ -32,7 +32,6 @@ IMAGES = {
                 # https://github.com/lima-vm/socket_vmnet/pull/56
                 "no_timer_check",
             ],
-            "initrd": f"https://cloud-images.ubuntu.com/releases/{UBUNTU_RELEASE}/release/unpacked/ubuntu-{UBUNTU_RELEASE}-server-cloudimg-amd64-initrd-generic",
         },
     },
     "alpine": {


### PR DESCRIPTION
## Switch to Ubuntu Minimal cloud image

Switch test VMs from the Ubuntu server cloud image (~850MB) to the
minimal cloud image (~407MB for amd64v3, ~390MB for arm64). This cuts
CI boot times from 2:30-5:00 minutes to 1:15-1:54, and local VM disk
usage from 2.6GB to 1.2GB per VM.

Changes:

- Use minimal cloud image for both arm64 and x86_64
- Use x86-64-v3 variant for Intel (all targets are macOS 14+ / Coffee Lake)
- Drop initrd for direct kernel boot (minimal kernel has virtio_blk and
  ext4 built-in)
- Use root=/dev/vda1 instead of root=LABEL=cloudimg-rootfs (minimal uses
  PARTUUID, not filesystem labels)
- Mask systemd-networkd-wait-online which may block boot for 2 minutes
- Revert CI timeout from 600s back to 300s

Boot time improvement (local, vfkit arm64):

    Before: Startup finished in 68ms (kernel) + 2min 1.668s (userspace)
    After:  Startup finished in 68ms (kernel) + 1.668s (userspace) = 1.737s

CI "Start example VM" step improvement:

    Before: 2:30 - 5:00+
    After:  1:15 - 1:54

## Example boot in 1.7 seconds

<img width="1071" height="4430" alt="boot-4" src="https://github.com/user-attachments/assets/d9ece56b-d2b2-4fe0-a333-19eef232c058" />
