### PR TITLE
docs: add timesync and guest agent config

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -90,6 +90,24 @@ users:
       - "$(cat ~/.ssh/id_ed25519.pub)"
 packages:
   - avahi-daemon
+  - qemu-guest-agent
+write_files:
+  - path: /etc/systemd/system/qemu-guest-agent.service
+    content: |
+      [Unit]
+      Description=QEMU Guest Agent
+
+      [Service]
+      ExecStart=/usr/sbin/qemu-ga --method=vsock-listen --path=3:1234
+      Restart=always
+      RestartSec=0
+
+      [Install]
+      WantedBy=multi-user.target
+runcmd:
+  - systemctl daemon-reload
+  - systemctl disable qemu-guest-agent
+  - systemctl enable --now qemu-guest-agent
 bootcmd:
   - systemctl mask systemd-networkd-wait-online.service
 EOF
@@ -151,6 +169,8 @@ cat > ~/Library/LaunchAgents/local.$VM_NAME.plist << EOF
         <string>virtio-net,type=unixgram,fd=4,mac=$MAC_ADDRESS,offloading=on</string>
         <string>--device</string>
         <string>virtio-rng</string>
+        <string>--timesync</string>
+        <string>vsockPort=1234</string>
     </array>
     <key>RunAtLoad</key>
     <false/>

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -338,7 +338,27 @@ users:
 packages:
   - avahi
   - podman
+write_files:
+  - path: /etc/systemd/system/qemu-guest-agent.service
+    content: |
+      [Unit]
+      Description=QEMU Guest Agent
+
+      [Service]
+      ExecStart=/usr/bin/qemu-ga --method=vsock-listen --path=3:1234
+      Restart=always
+      RestartSec=0
+
+      [Install]
+      WantedBy=multi-user.target
+  - path: /root/qemu-ga-vsock.cil
+    content: |
+      (allow virt_qemu_ga_t self (vsock_socket (bind create getattr listen accept read write)))
 runcmd:
+  - semodule -i /root/qemu-ga-vsock.cil
+  - systemctl daemon-reload
+  - systemctl disable qemu-guest-agent
+  - systemctl enable --now qemu-guest-agent
   - systemctl enable --now avahi-daemon
   - systemctl enable --now podman.socket
 EOF
@@ -400,6 +420,8 @@ cat > ~/Library/LaunchAgents/local.$VM_NAME.plist << EOF
         <string>virtio-net,type=unixgram,fd=4,mac=$MAC_ADDRESS,offloading=on</string>
         <string>--device</string>
         <string>virtio-rng</string>
+        <string>--timesync</string>
+        <string>vsockPort=1234</string>
     </array>
     <key>RunAtLoad</key>
     <false/>

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -95,7 +95,25 @@ users:
 packages:
   - avahi
   - podman
+write_files:
+  - path: /etc/systemd/system/qemu-guest-agent.service
+    content: |
+      [Unit]
+      Description=QEMU Guest Agent
+      [Service]
+      ExecStart=/usr/bin/qemu-ga --method=vsock-listen --path=3:1234
+      Restart=always
+      RestartSec=0
+      [Install]
+      WantedBy=multi-user.target
+  - path: /root/qemu-ga-vsock.cil
+    content: |
+      (allow virt_qemu_ga_t self (vsock_socket (bind create getattr listen accept read write)))
 runcmd:
+  - semodule -i /root/qemu-ga-vsock.cil
+  - systemctl daemon-reload
+  - systemctl disable qemu-guest-agent
+  - systemctl enable --now qemu-guest-agent
   - systemctl enable --now avahi-daemon
   - systemctl enable --now podman.socket
 EOF
@@ -156,6 +174,8 @@ cat > ~/Library/LaunchAgents/local.$VM_NAME.plist << EOF
         <string>virtio-net,fd=4,mac=$MAC_ADDRESS</string>
         <string>--device</string>
         <string>virtio-rng</string>
+        <string>--timesync</string>
+        <string>vsockPort=1234</string>
     </array>
     <key>RunAtLoad</key>
     <false/>


### PR DESCRIPTION
Configure qemu-guest-agent to listen on vsock port 1234 and add
--timesync vsockPort=1234 to the vfkit and krunkit commands in the
podman and docker tutorials. This syncs the guest clock after the
host wakes from sleep.

The default qemu-guest-agent.service depends on a virtio-serial
device that neither vfkit nor krunkit provide. The service would
never start since the device does not exist. We replace it with a
unit file in /etc/systemd/system/ that uses vsock and starts via
multi-user.target. The runcmd uses "disable" then "enable --now"
to remove the stale symlinks from the original device target and
create new ones for multi-user.target.

On Fedora (podman tutorial), the SELinux policy for virt_qemu_ga_t
only allows virtio-serial communication. We install a CIL policy
module to allow vsock socket operations, matching the policy used
by podman-machine-os. On Ubuntu (docker tutorial), AppArmor does
not restrict vsock access so no policy changes are needed, but
qemu-guest-agent must be added to the cloud-init packages list
since it is not pre-installed.

When vfkit/krunkit starts with --timesync vsockPort=1234, it
monitors the host for sleep/resume events. After resume, it
connects to the guest agent over vsock port 1234 and sends the
current host time to correct the guest clock, which stopped
during host sleep.